### PR TITLE
Copy xml files to the output directory

### DIFF
--- a/Exdi/exdigdbsrvsample/ExdiGdbSrvSample/ExdiGdbSrvSample.vcxproj
+++ b/Exdi/exdigdbsrvsample/ExdiGdbSrvSample/ExdiGdbSrvSample.vcxproj
@@ -238,6 +238,11 @@
       <Command>
       </Command>
     </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)\GdbSrvControllerLib\exdiConfigData.xml" "$(TargetDir)\exdiConfigData.xml"
+copy "$(SolutionDir)\GdbSrvControllerLib\systemregisters.xml" "$(TargetDir)\systemregisters.xml"
+</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/Exdi/exdigdbsrvsample/GdbSrvControllerLib/exdiConfigData.xml
+++ b/Exdi/exdigdbsrvsample/GdbSrvControllerLib/exdiConfigData.xml
@@ -179,7 +179,7 @@
   <!-- QEMU SW simulator GDB server configuration -->
   <ExdiTarget Name = "QEMU">
     <ExdiGdbServerConfigData agentNamePacket = "" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "yes" qSupportedPacket="qSupported:xmlRegisters=aarch64,i386">
-      <ExdiGdbServerTargetData targetArchitecture = "ARM64" targetFamily = "ProcessorFamilyARM64" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xfffe" targetDescriptionFile = "target.xml" />
+      <ExdiGdbServerTargetData targetArchitecture = "ARM64" targetFamily = "ProcessorFamilyARM64" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xffe" targetDescriptionFile = "target.xml" />
       <GdbServerConnectionParameters MultiCoreGdbServerSessions = "no" MaximumGdbServerPacketLength = "1024" MaximumConnectAttempts = "3" SendPacketTimeout = "100" ReceivePacketTimeout = "3000">
         <Value HostNameAndPort="LocalHost:1234" />
       </GdbServerConnectionParameters>


### PR DESCRIPTION
This PR includes two changes:

- Copy exdiConfigData.xml (configure the exdi session) and systemregisters.xml (mapping between system reg. name and its access code) to the project out directory.
- Modify the heuristicScanSize attribute value (in exdiConfigData.xml file) for the QEMU Gdb Server.
