### PR TITLE
Iter 1, Added handling of OK in stop reply OpenOCD response

### DIFF
--- a/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
+++ b/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
@@ -1862,6 +1862,14 @@ ADDRESS_TYPE CLiveExdiGdbSrvServer::ParseAsynchronousCommandResult(_Out_ DWORD *
                     *pProcessorNumberOfLastEvent = pController->GetLastKnownActiveCpu();
                     isWaitingOnStopReply = false;
                 } 
+                // Is it an "OK" response w/o any other field (e.g. OpenOCD can send "OK" after 's'/'g')?
+                else if (stopReply.status.isCoreRunning)
+                {
+                    //  Post another receive request on the packet buffer, since there is still no
+                    //  trace of the current thread-core/Pc address packet.
+                    pController->ContinueWaitingOnStopReplyPacket();
+                    isWaitingOnStopReply = true;                
+                }
 
                 if (!isWaitingOnStopReply)
                 {

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/AsynchronousGdbSrvController.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/AsynchronousGdbSrvController.cpp
@@ -702,6 +702,13 @@ void AsynchronousGdbSrvController::HandleStopReply(_In_ const std::string reply,
         *pEventNotification = true;
         *pProcessorNumber = GdbSrvController::GetLastKnownActiveCpu();
     }
+    // Is it an "OK" response w/o any other field (e.g. OpenOCD can send this after 's'/'g')?
+    else if (stopReply.status.isCoreRunning)
+    {
+        //  Post another receive request on the packet buffer, since there is still no
+        //  trace of the current thread/address packet.
+        ContinueWaitingOnStopReplyPacket();
+    }
 }
 
 void AsynchronousGdbSrvController::ContinueWaitingOnStopReplyPacket()


### PR DESCRIPTION
This PR includes handling of OK response for stop reply response packets after "O" console display packets and before the actual stop reply response arrive (this "OK" pattern has been observed only for OpenOCD)