### PR TITLE
Enable treating SW bps as HW bps

### DIFF
--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/AsynchronousGdbSrvController.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/AsynchronousGdbSrvController.cpp
@@ -175,11 +175,13 @@ unsigned AsynchronousGdbSrvController::CreateCodeBreakpoint(_In_ AddressType add
         m_breakpointSlots.push_back(false);
     }
 
-    char breakCmd[128] = {0}; 
+    ConfigExdiGdbServerHelper& cfgData = ConfigExdiGdbServerHelper::GetInstanceCfgExdiGdbServer(nullptr);
+    PCSTR pBpCommand = (cfgData.GetTreatSwBpAsHwBp()) ? "Z1" : "Z0";
     TargetArchitecture targetArchitecture = GdbSrvController::GetTargetArchitecture();
     PCSTR pFormat = (targetArchitecture == ARM64_ARCH || targetArchitecture == AMD64_ARCH) ?
-                     "Z0,%I64x,%d" : "Z0,%x,%d";
-    sprintf_s(breakCmd, _countof(breakCmd), pFormat, address, GetBreakPointSize());
+                     "%s,%I64x,%d" : "%s,%x,%d";
+    char breakCmd[128] = { 0 };
+    sprintf_s(breakCmd, _countof(breakCmd), pFormat, pBpCommand, address, GetBreakPointSize());
 
     bool isReplyOK = false;
     unsigned totalNumberOfCores = GdbSrvController::GetNumberOfRspConnections();
@@ -239,11 +241,13 @@ void AsynchronousGdbSrvController::DeleteCodeBreakpoint(_In_ unsigned breakpoint
         throw std::exception("Trying to delete nonexisting breakpoint");
     }
 
-    char breakCmd[128] = {0}; 
+    ConfigExdiGdbServerHelper& cfgData = ConfigExdiGdbServerHelper::GetInstanceCfgExdiGdbServer(nullptr);
+    PCSTR pBpCommand = (cfgData.GetTreatSwBpAsHwBp()) ? "z1" : "z0";
     TargetArchitecture targetArchitecture = GdbSrvController::GetTargetArchitecture();
     PCSTR pFormat = (targetArchitecture == ARM64_ARCH || targetArchitecture == AMD64_ARCH) ?
-                     "z0,%I64x,%d" : "z0,%x,%d";     
-    sprintf_s(breakCmd, _countof(breakCmd), pFormat, address, GetBreakPointSize());
+                     "%s,%I64x,%d" : "%s,%x,%d";
+    char breakCmd[128] = { 0 };
+    sprintf_s(breakCmd, _countof(breakCmd), pFormat, pBpCommand, address, GetBreakPointSize());
 
     bool isReplyOK = false;
     unsigned totalNumberOfCores = GdbSrvController::GetNumberOfRspConnections();
@@ -281,13 +285,13 @@ void AsynchronousGdbSrvController::DeleteCodeBreakpoint(_In_ unsigned breakpoint
 //
 //  Request:
 //  For daWrite breakpoint type:
-//    Z2,address,accessWidth     
+//    Z2,address,accessWidth
 //
 //  For daRead breakpoint type:
-//    Z3,address,accessWidth     
+//    Z3,address,accessWidth
 //
 //  For daBoth breakpoint type:
-//    Z4,address,accessWidth     
+//    Z4,address,accessWidth
 //
 //  Response:
 //  'OK'                    if the command succeeded.

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.cpp
@@ -1572,7 +1572,7 @@ public:
                     //  Yes, return the current stored length
                     //  and let the caller's handles the returned data.
                     fError = true;
-                    // ... unless we didn't read anything, in which case fail
+                    //  unless we didn't read anything, in which case fail
                     if (recvLength == 0 && GetThrowExceptionEnabled())
                     {
                         throw _com_error(E_FAIL);

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.cpp
@@ -98,6 +98,7 @@ typedef struct
     WCHAR fExceptionThrowEnabled[C_MAX_ATTR_LENGTH];    //  Allow throwing exception by the Exdi COM server.
                                                         //  Used to disallow throwing exceptions when memory failures occur.
     WCHAR qSupportedPacket[C_MAX_ATTR_LENGTH];          //  qSupported packet to send to the dbg server, if empty then just "qSupported"
+    WCHAR fTreatSwBpAsHwBp[C_MAX_ATTR_LENGTH];          //  Treat SW bp as a HW bp.
 } ConfigExdiDataEntry;
 
 typedef struct
@@ -172,6 +173,7 @@ const WCHAR gdbServerConnectionParameters[] = L"GdbServerConnectionParameters";
 const WCHAR gdbServerConnectionValue[] = L"Value";
 const WCHAR gdbServerAgentNamePacket[] = L"agentNamePacket";
 const WCHAR gdbQSupportedPacket[] = L"qSupportedPacket";
+const WCHAR gdbTreatSwBpAsHwBp[] = L"enableTreatingSwBpAsHwBp";
 const WCHAR gdbServerUuid[] = L"uuid";
 const WCHAR displayCommPackets[] = L"displayCommPackets";
 const WCHAR debuggerSessionByCore[] = L"debuggerSessionByCore";
@@ -247,6 +249,7 @@ const XML_ATTRNAME_HANDLER_STRUCT attrExdiServerHandlerMap[] =
     {exdiGdbServerConfigData, debuggerSessionByCore,    XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fDebuggerSessionByCore), C_MAX_ATTR_LENGTH},
     {exdiGdbServerConfigData, enableThrowExceptions,    XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fExceptionThrowEnabled), C_MAX_ATTR_LENGTH},
     {exdiGdbServerConfigData, gdbQSupportedPacket,      XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, qSupportedPacket), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbTreatSwBpAsHwBp,       XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fTreatSwBpAsHwBp), C_MAX_ATTR_LENGTH},
 };
 
 //  Attribute name - handler map for the GdbServer server tag info
@@ -802,6 +805,7 @@ HRESULT XmlDataHelpers::HandleTagAttributeList(_In_ TAG_ATTR_LIST* const pTagAtt
                     pConfigTable->component.fDebuggerSessionByCore = (_wcsicmp(exdiData.fDebuggerSessionByCore, L"yes") == 0) ? true : false;
                     pConfigTable->component.fExceptionThrowEnabled = (_wcsicmp(exdiData.fExceptionThrowEnabled, L"yes") == 0) ? true : false;
                     pConfigTable->component.qSupportedPacket = exdiData.qSupportedPacket;
+                    pConfigTable->component.fTreatSwBpAsHwBp = (_wcsicmp(exdiData.fTreatSwBpAsHwBp, L"yes") == 0) ? true : false;
                     isSet = true;
                 }
             }

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.h
@@ -55,6 +55,7 @@ namespace GdbSrvControllerLib
         bool fExceptionThrowEnabled;    //  Allow throwing exception by the Exdi COM server.
                                         //  Used to disallow throwing exceptions when memory failures occur.
         std::wstring qSupportedPacket;  //  GDB server supported, if this empty then will send the default "qsupported" packet
+        bool fTreatSwBpAsHwBp;          //  GDB server client will convert SW bp as HW bp.
     } ConfigExdiData;
 
     //  This type indicates the Target data.

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.cpp
@@ -329,6 +329,11 @@ class ConfigExdiGdbServerHelper::ConfigExdiGdbServerHelperImpl
         }
     }
 
+    inline bool ConfigExdiGdbServerHelperImpl::GetTreatSwBpAsHwBp() const
+    {
+        return m_ExdiGdbServerData.component.fTreatSwBpAsHwBp;
+    }
+
     private:
     CComPtr<IXmlReader> m_XmlLiteReader;
     CComPtr<IStream> m_IStream;
@@ -850,6 +855,12 @@ void ConfigExdiGdbServerHelper::GetSystemRegistersMapAccessCode(_Out_ unique_ptr
 {
     assert(m_pConfigExdiGdbServerHelperImpl != nullptr);
     m_pConfigExdiGdbServerHelperImpl->GetSystemRegistersMapAccessCode(spMapSystemRegs);
+}
+
+bool ConfigExdiGdbServerHelper::GetTreatSwBpAsHwBp()
+{
+    assert(m_pConfigExdiGdbServerHelperImpl != nullptr);
+    return m_pConfigExdiGdbServerHelperImpl->GetTreatSwBpAsHwBp();
 }
 
 void ConfigExdiGdbServerHelper::SetTargetArchitecture(_In_ TargetArchitecture targetArch)

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.h
@@ -50,6 +50,7 @@ class ConfigExdiGdbServerHelper final
         void GetGdbServerRegisters(_Out_ unique_ptr<vector<RegistersStruct>>* spRegisters);
         void GetGdbServerSystemRegisters(_Out_ unique_ptr<vector<RegistersStruct>>* spSystemRegisters);
         void GetSystemRegistersMapAccessCode(_Out_ unique_ptr<SystemRegistersMapType>* spMapSystemRegs);
+        bool GetTreatSwBpAsHwBp();
         bool IsExceptionThrowEnabled();
         bool IsSupportedSpecialMemoryCommand();
         bool IsSupportedPhysicalMemoryCommand();

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
@@ -90,7 +90,7 @@
 
   <!-- BMC-OpenOCD HW debugger GDB server configuration -->
   <ExdiTarget Name = "BMC-OpenOCD">
-    <ExdiGdbServerConfigData agentNamePacket = "BMC.OpenOCD.Windbg.Gdb" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "yes" qSupportedPacket="qSupported:xmlRegisters=aarch64,i386" >
+    <ExdiGdbServerConfigData agentNamePacket = "BMC.OpenOCD.Windbg.Gdb" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "yes" qSupportedPacket="qSupported:xmlRegisters=aarch64,i386" enableTreatingSwBpAsHwBp="yes" >
       <ExdiGdbServerTargetData targetArchitecture = "ARM64" targetFamily = "ProcessorFamilyARM64" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xfffe" targetDescriptionFile = "target.xml" />
       <GdbServerConnectionParameters MultiCoreGdbServerSessions = "no" MaximumGdbServerPacketLength = "1024" MaximumConnectAttempts = "3" SendPacketTimeout = "100" ReceivePacketTimeout = "3000">
         <Value HostNameAndPort="LocalHost:3333" />


### PR DESCRIPTION
- 

- This PR enables treating SW breakpoints as a HW bps. 
> So when a SW breakpoint is set by the debugger (before any target resume function, i.e. 'g'/'p'/'t'), then the GDB client will send a GDB 'Z1' packet rather than a 'Z0' packet. The same applies for removing breakpoints 'z1' instead of 'z0'. 

- Added a xml attribute (enableTreatingSwBpAsHwBp) to control if the GDB server requires this feature (i.e. BMC-OpenOCD, where SW bps do *not* work it).