### PR TITLE
Fix an ancient ReadMemory() bug

### DIFF
--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.cpp
@@ -1594,14 +1594,14 @@ public:
                     result[result.GetLength() - 1] = static_cast<char>(value);
                     recvLength++;
                 }
-                //  Are we done with the requested data?
-                if (recvLength >= size || size == 0 || messageLength == 0)
-                {
-                    break;
-                }
                 //  Update the parameters for the next packet.
                 address += recvLength;
                 size -= recvLength;
+                //  Are we done with the requested data?
+                if (size == 0 || messageLength == 0)
+                {
+                    break;
+                }
             }
             if (fError)
             {


### PR DESCRIPTION
This PR includes a fix to successfully shop the packets in the ReadMemory() function. The issue appears only when the user request to read more than the default configured xml maximum buffer length.