### PR TITLE
Fix the hang regression caused by the Ampere patch.

### DIFF
--- a/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
+++ b/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
@@ -219,11 +219,6 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::Halt(void)
                 hr = E_NOTIMPL;
             }
         }
-        else
-        {
-            MessageBox(0, _T("Fatal error the Notification listener is not defined."),nullptr, MB_ICONERROR);
-            hr = E_NOTIMPL;
-        }
 
         return hr;
     }
@@ -536,7 +531,6 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::ReadVirtualMemory(
         {
             return E_POINTER;
         }
-
         memoryAccessType memType = {0};
         pController->GetMemoryPacketType(m_lastPSRvalue, &memType);
 
@@ -1038,7 +1032,7 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::GetContextEx(_In_ DWORD process
         {
             return E_POINTER;
         }
-
+        pController->StopTargetAtRun();
         memset(pContext, 0, sizeof(CONTEXT_ARM4));
 
         std::map<std::string, std::string> registers = pController->QueryAllRegisters(processorNumber);
@@ -1112,6 +1106,7 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::SetContextEx(_In_ DWORD process
         {
             return E_POINTER;
         }
+        pController->StopTargetAtRun();
         std::map<std::string, ULONGLONG> registers;
         if (pContext->RegGroupSelection.fIntegerRegs)
         {
@@ -1162,7 +1157,7 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::GetContextEx(_In_ DWORD process
         {
             return E_POINTER;
         }
-
+        pController->StopTargetAtRun();
         memset(pContext, 0, sizeof(CONTEXT_X86_64));
 
         //We do not fetch the actual descriptors, thus we mark them as invalid
@@ -1274,6 +1269,7 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::SetContextEx(_In_ DWORD process
         {
             return E_POINTER;
         }
+        pController->StopTargetAtRun();
         std::map<std::string, ULONGLONG> registers;
         if (pContext->RegGroupSelection.fIntegerRegs)
         {
@@ -1374,7 +1370,7 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::GetContextEx(_In_ DWORD process
         {
             return E_POINTER;
         }
-
+        pController->StopTargetAtRun();
         memset(pContext, 0, sizeof(CONTEXT_X86_EX));
 
         pContext->DescriptorCs.Flags = static_cast<DWORD>(X86_DESC_FLAGS);
@@ -1419,7 +1415,7 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::SetContextEx(_In_ DWORD process
         {
             return E_POINTER;
         }
-
+        pController->StopTargetAtRun();
         SetX86CoreRegisters(processorNumber, pContext, pController);
 
         SetFPCoprocessorRegisters(processorNumber, reinterpret_cast<const VOID *>(pContext), pController);
@@ -2094,7 +2090,7 @@ void CLiveExdiGdbSrvServer::GetNeonRegisters(_In_ AsynchronousGdbSrvController *
 }
 
 void CLiveExdiGdbSrvServer::SetNeonRegisters(_In_ DWORD processorNumber, _In_ const VOID * pContext,
-                                                   _In_ AsynchronousGdbSrvController * const pController)
+                                             _In_ AsynchronousGdbSrvController * const pController)
 {
     assert(pContext != nullptr && pController != nullptr);
 

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/AsynchronousGdbSrvController.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/AsynchronousGdbSrvController.h
@@ -61,6 +61,8 @@ namespace GdbSrvControllerLib
             _Inout_ AddressType* pPcAddress, _Out_ DWORD* pProcessorNumber, _Out_ bool* pEventNotification);
         ~AsynchronousGdbSrvController();
         void StopTargetAtRun();
+        void SetInterruptEvent();
+        bool IsLastCommandTargetRun();
 
     protected:
         AsynchronousGdbSrvController(_In_ const std::vector<std::wstring> &coreConnectionParameters);

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.h
@@ -324,6 +324,9 @@ namespace GdbSrvControllerLib
         //  Set the system register map file path
         void SetSystemRegisterXmlFile(_In_z_ PCWSTR pSystemRegFilePath);
 
+        //  Set event interrupt
+        void SetInterruptEvent();
+
     protected:
         bool IsReplyOK(_In_ const std::string & reply);
 

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.vcxproj
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.vcxproj
@@ -177,6 +177,7 @@ midl /env x64 /out".\GeneratedSources" /h "ExdiGdbSrv.h" /W1 /I"..\ExdiGdbSrv"  
     <ClInclude Include="HandleHelpers.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="TargetArchitectureHelpers.h" />
+    <ClInclude Include="TargetGdbServerHelpers.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="TcpConnectorStream.h" />
     <ClInclude Include="XmlDataHelpers.h" />

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.vcxproj.filters
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="XmlDataHelpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="TargetGdbServerHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -77,13 +80,5 @@
     <ClCompile Include="XmlDataHelpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <Xml Include="exdiConfigData.xml">
-      <Filter>Source Files</Filter>
-    </Xml>
-    <Xml Include="systemregisters.xml">
-      <Filter>Source Files</Filter>
-    </Xml>
   </ItemGroup>
 </Project>

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvRspClient.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvRspClient.h
@@ -182,7 +182,19 @@ namespace GdbSrvControllerLib
         // Set Feature option enable
         void SetFeatureEnable(_In_ unsigned feature);
 
-	    private:
+        // Set the interrupt event
+        void SetInterrupt();
+
+        // Clear user initiated interrupt event
+        void ClearInterruptFlag() { m_fInterruptFlag = false; }
+
+        // Get status user interrupt flag
+        bool GetInterruptFlag() const { return m_fInterruptFlag; }
+
+        // Set user initiated interrupt flag
+        void SetInterruptFlag(_In_ bool flag) { m_fInterruptFlag = flag; }
+
+        private:
         ValidHandleWrapper m_interruptEvent;
         unique_ptr <TConnectStream> m_pConnector;
         static PacketConfig s_RspProtocolFeatures[MAX_FEATURES];
@@ -195,5 +207,6 @@ namespace GdbSrvControllerLib
         void SetProtocolFeatureFlag(_In_ size_t index, _In_ bool value);
         bool GetNoAckModeRequired(_In_ const string & command);
         bool SendRspInterruptEx(_In_ bool fResetAllCores, _In_ unsigned activeCore);
+        bool m_fInterruptFlag;
     }; 
 }

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/TargetArchitectureHelpers.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/TargetArchitectureHelpers.h
@@ -388,7 +388,6 @@ public:
             MessageBox(0, _T("Target architecture is not supported"), _T("EXDI-GdbServer"), MB_ICONERROR);
         }
     }
-
 };
 
 #pragma endregion

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/TargetGdbServerHelpers.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/TargetGdbServerHelpers.h
@@ -1,0 +1,172 @@
+//----------------------------------------------------------------------------
+//
+// TargetGdbServerHelpers.h
+//
+// Helpers to handle specific Gdb server target comands
+//
+// Copyright (c) Microsoft. All rights reserved.
+//----------------------------------------------------------------------------
+
+#pragma once
+#include "stdafx.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string>
+#include <memory>
+#include <vector>
+#include "TextHelpers.h"
+#include "HandleHelpers.h"
+#include "GdbSrvControllerLib.h"
+
+using namespace GdbSrvControllerLib;
+using namespace std;
+
+//
+//  Gdb server related constans
+//
+
+
+// ************************************************************************************
+//
+#pragma region Target GDB server helpers
+
+class Trace32GdbServerMemoryHelpers
+{
+public:
+
+    static inline PCSTR GetGdbSrvReadMemoryCmd(
+        _In_ memoryAccessType memType,
+        _In_ bool is64BitArchitecture,
+        _In_ TargetArchitecture targetArchitecture)
+    {
+        PCSTR pFormat = nullptr;
+
+        if (memType.isPhysical)
+        {
+            pFormat = (is64BitArchitecture) ? "qtrace32.memory:a,%I64x,%x" : "qtrace32.memory:a,%x,%x";
+        }
+        else if (memType.isSupervisor)
+        {
+            pFormat = (is64BitArchitecture) ? "qtrace32.memory:s,%I64x,%x" : "qtrace32.memory:s,%x,%x";
+        }
+        else if (memType.isHypervisor)
+        {
+            pFormat = (is64BitArchitecture) ? "qtrace32.memory:h,%I64x,%x" : "qtrace32.memory:h,%x,%x";
+        }
+        else if (memType.isSpecialRegs)
+        {
+            if (targetArchitecture == ARM64_ARCH)
+            {
+                pFormat = "qtrace32.memory:SPR,%x,%x";
+            }
+            else if (targetArchitecture == ARM32_ARCH)
+            {
+                pFormat = "qtrace32.memory:C15,%x,%x";
+            }
+            else
+            {
+                assert(false);
+            }
+        }
+        return pFormat;
+    }
+
+    static inline PCSTR GetGdbSrvWriteMemoryCmd(
+        _In_ memoryAccessType memType,
+        _In_ bool is64BitArchitecture,
+        _In_ TargetArchitecture targetArchitecture)
+    {
+        PCSTR pFormat = nullptr;
+
+        if (memType.isPhysical)
+        {
+            pFormat = (is64BitArchitecture) ? "Qtrace32.memory:a,%I64x," : "Qtrace32.memory:a,%x,";
+        }
+        else if (memType.isSupervisor)
+        {
+            pFormat = (is64BitArchitecture) ? "Qtrace32.memory:s,%I64x," : "Qtrace32.memory:s,%x,";
+        }
+        else if (memType.isHypervisor)
+        {
+            pFormat = (is64BitArchitecture) ? "Qtrace32.memory:h,%I64x," : "Qtrace32.memory:h,%x,";
+        }
+        else if (memType.isSpecialRegs)
+        {
+            if (targetArchitecture == ARM64_ARCH)
+            {
+                pFormat = "Qtrace32.memory:SPR,%x,";
+            }
+            else if (targetArchitecture == ARM32_ARCH)
+            {
+                pFormat = "Qtrace32.memory:C15,%x,";
+            }
+            else
+            {
+                assert(false);
+            }
+        }
+
+        return pFormat;
+    }
+};
+
+class OpenOCDGdbServerMemoryHelpers
+{
+public:
+
+    static inline PCSTR GetGdbSrvReadMemoryCmd(
+        _In_ memoryAccessType memType,
+        _In_ bool is64BitArchitecture)
+    {
+
+        PCSTR pFormat = nullptr;
+
+        if (memType.isSpecialRegs)
+        {
+            //  Is it an OpenOCD GDB server
+            pFormat = (is64BitArchitecture) ? "aarch64 mrs nsec %d %d %d %d %d" : "amd64 mrs nsec %d %d %d %d %d";
+        }
+/*
+        @TODO: Modify the below code with the correct command, once OpenOCD
+        provides a reliable command for reading physical memory.
+        else if (memType.isPhysical)
+        {
+            pFormat = (is64BitArchitecture) ? "mdb phys %I64x %d" : "mdb phys %x %d";
+        }
+*/
+        else
+        {
+            pFormat = is64BitArchitecture ? "m%I64x,%x" : "m%x,%x";
+        }
+        return pFormat;
+    }
+
+    static inline PCSTR GetGdbSrvWriteMemoryCmd(
+        _In_ memoryAccessType memType,
+        _In_ bool is64BitArchitecture)
+    {
+        PCSTR pFormat = nullptr;
+
+        if (memType.isSpecialRegs)
+        {
+            pFormat = (is64BitArchitecture) ? "aarch64 mrs nsec %d %d %d %d %d %x" : "amd64 mrs nsec %d %d %d %d %d %x";
+        }
+/*      
+        @TODO: Modify the below code with the correct command, once OpenOCD
+        provides a reliable command for writing physical memory.
+        else if (memType.isPhysical)
+        {
+            pFormat = (is64BitArchitecture) ? "mwb phys %I64x %d" : "mwb phys %x %d";
+        }
+*/
+        else
+        {
+            pFormat = is64BitArchitecture ? "M%I64x," : "M%x,";
+        }
+
+        return pFormat;
+    }
+};
+
+#pragma endregion
+#pragma once


### PR DESCRIPTION
This PR includes the following fixes:

- Fix the hang scenario by handling the extended GDB resume command introduced by the Ampere patch.
- Add handling for the same hang scenario on x64 architecture (it was missed to be handled when x64 arch. was recently implemented).
- Refactor the code around the handling of the hang scenario, so GDB client does *not* send a gratuitous break/interrupt request, and rather interrupt the thread waiting, since the break stop reply response was already handled by the interrupt command.
_Refactor the reading memory commands based on GDB types.