### PR TITLE
Fix the issue related to missing asynchronous response packets (i.e. long waiting stop-reply responses, blind HW bps).

### DIFF
--- a/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
+++ b/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
@@ -1684,9 +1684,6 @@ DWORD CALLBACK CLiveExdiGdbSrvServer::NotificationThreadBody(LPVOID p)
     assert(SUCCEEDED(result));
     UNREFERENCED_PARAMETER(result);
 
-    ConfigExdiGdbServerHelper & cfgData = ConfigExdiGdbServerHelper::GetInstanceCfgExdiGdbServer(nullptr);
-    DWORD waitTimeout = (cfgData.GetMultiCoreGdbServer()) ? INFINITE : 6000;  
-
     for (;;)
     {
         DWORD waitResult = WaitForSingleObject(pServer->m_notificationSemaphore, 100);
@@ -1712,7 +1709,7 @@ DWORD CALLBACK CLiveExdiGdbSrvServer::NotificationThreadBody(LPVOID p)
 
             if (waitResult == WAIT_OBJECT_0)
             {
-                if (pController->GetAsynchronousCommandResult(waitTimeout, nullptr))
+                if (pController->GetAsynchronousCommandResult(INFINITE, nullptr))
                 {
                     pReceiver->OnAsynchronousCommandCompleted();
                 }


### PR DESCRIPTION
This PR will fix the Andrea's reported issue about ExdiGdbSrv.dll did not break after setting a blind HW bp.
