### PR TITLE
Merge new Symbol Builder sample into master.

### DIFF
--- a/TargetComposition/SymBuilder/ApiProvider.cpp
+++ b/TargetComposition/SymBuilder/ApiProvider.cpp
@@ -1,0 +1,1874 @@
+//**************************************************************************
+//
+// ApiProvider.cpp
+//
+// A provider for the data model which extends Debugger.Utility.*
+// to create new APIs to access our underlying functionality.
+//
+// The provider here is implemented with the C++17 data model client library.
+// Effectively, there are a series of classes whose constructors bind certain C++ methods
+// to the data model as property getters and setters or method callbacks.
+//
+// The global ApiProvider object houses all of these classes.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+#include "ObjectModel.h"
+
+using namespace Debugger::DataModel::ClientEx;
+using namespace Debugger::DataModel::ProviderEx;
+using namespace Debugger::TargetComposition::Services::SymbolBuilder;
+using namespace Microsoft::WRL;
+
+//*************************************************
+// Global State
+//
+// This is global state required to be a data model provider extension using the
+// DbgModelClientEx.h library.
+//
+
+Debugger::DataModel::Libraries::SymbolBuilder::ApiProvider *g_pProvider = nullptr;
+IDataModelManager *g_pManager = nullptr;
+IDebugHost *g_pHost = nullptr;
+
+namespace Debugger::DataModel::ClientEx
+{
+    IDataModelManager *GetManager() { return g_pManager; }
+    IDebugHost *GetHost() { return g_pHost; }
+}
+
+namespace Debugger
+{
+namespace DataModel
+{
+namespace Libraries
+{
+namespace SymbolBuilder
+{
+
+//*************************************************
+// Standard Helpers:
+//
+
+// ValueToString():
+//
+// Performs our string conversion of a constant valued symbol.
+//
+std::wstring ValueToString(_In_ VARIANT const& val)
+{
+    wchar_t buf[128];
+
+    switch(val.vt)
+    {
+        case VT_BOOL:
+            return (val.boolVal != VARIANT_FALSE) ? L"true" : L"false";
+
+        case VT_I1:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%d", (int)(val.cVal));
+            break;
+        }
+
+        case VT_I2:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%d", (int)(val.iVal));
+            break;
+        }
+
+        case VT_I4:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%d", (int)(val.lVal));
+            break;
+        }
+
+        case VT_I8:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%I64d", val.llVal);
+            break;
+        }
+
+        case VT_UI1:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%ud", (unsigned int)(val.bVal));
+            break;
+        }
+
+        case VT_UI2:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%ud", (unsigned int)(val.uiVal));
+            break;
+        }
+
+        case VT_UI4:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%ud", (unsigned int)(val.ulVal));
+            break;
+        }
+
+        case VT_UI8:
+        {
+            swprintf_s(buf, ARRAYSIZE(buf), L"%I64u", val.ullVal);
+            break;
+        }
+
+        default:
+            throw std::runtime_error("illegal constant value");
+    }
+
+    return (std::wstring)buf;
+}
+
+//*************************************************
+// Provider Implementation
+//
+
+// GetSymbolBuilderManager():
+//
+// A helper bridge interface which returns a reference counted pointer to the appropriate symbol builder manager
+// for the given host context.
+//
+// Note that this may throw on failure.
+//
+void GetSymbolBuilderManager(_In_ const HostContext& ctx,
+                             _COM_Outptr_ ISvcSymbolBuilderManager **ppSymbolBuilderManager,
+                             _COM_Outptr_opt_ ISvcProcess **ppProcess)
+{
+    *ppSymbolBuilderManager = nullptr;
+    if (ppProcess != nullptr)
+    {
+        *ppProcess = nullptr;
+    }
+
+    //
+    // We need to go down a level from the data model into the target composition service container
+    // and find our "manager" to deal with things.
+    //
+    ComPtr<IDebugHostContextTargetComposition> spBridge;
+    CheckHr(ctx->QueryInterface(IID_PPV_ARGS(&spBridge)));
+
+    ComPtr<IDebugServiceManager> spServiceManager;
+    ComPtr<ISvcProcess> spServiceProcess;
+    CheckHr(spBridge->GetServiceManager(&spServiceManager));
+    if (ppProcess != nullptr)
+    {
+        CheckHr(spBridge->GetServiceProcess(&spServiceProcess));
+    }
+
+    //
+    // If we haven't *YET* injected our manager into *THIS* service container, do so now.
+    // We *COULD* have done this at DebugExtensionInitialize on the current container, but that would
+    // break multi-process debugging as we only get that notification once.  Since we are ONLY used when
+    // an API is called, this is just a convenient place to inject.
+    //
+    ComPtr<ISvcSymbolBuilderManager> spSymManager;
+    if (FAILED(spServiceManager->QueryService(DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER, 
+                                              IID_PPV_ARGS(&spSymManager))))
+    {
+        ComPtr<SymbolBuilderManager> spManager;
+        CheckHr(MakeAndInitialize<SymbolBuilderManager>(&spManager));
+        CheckHr(spManager->RegisterServices(spServiceManager.Get()));
+        spSymManager = std::move(spManager);
+
+        //
+        // If we never injected the manager, we never injected the symbol provider.
+        //
+        ComPtr<SymbolProvider> spProvider;
+        CheckHr(MakeAndInitialize<SymbolProvider>(&spProvider));
+
+        //
+        // If we call spProvider->RegisterServices(pServiceManager), it will *REPLACE* the symbol provider
+        // in the container with ours.  Instead, we will go to an updated interface on the service manager
+        // and ask it to aggregate the symbol provider (which means to insert it in a group).
+        //
+        // Most recent debuggers will support IDebugServiceManager5, but the alternative is shown in terms
+        // of handling updated interfaces more generally.
+        //
+        ComPtr<IDebugServiceManager5> spServiceManager5;
+        if (SUCCEEDED(spServiceManager.As(&spServiceManager5)))
+        {
+            CheckHr(spServiceManager5->AggregateService(DEBUG_SERVICE_SYMBOL_PROVIDER, spProvider.Get()));
+        }
+        else
+        {
+            CheckHr(spProvider->RegisterServices(spServiceManager.Get()));
+        }
+    }
+
+    *ppSymbolBuilderManager = spSymManager.Detach();
+    if (ppProcess != nullptr)
+    {
+        *ppProcess = spServiceProcess.Detach();
+    }
+}
+
+ApiProvider *ApiProvider::s_pProvider = nullptr;
+
+ApiProvider::ApiProvider()
+{
+    //
+    // The pattern here is that there is a *SINGLE* global ApiProvider constructed when we initialize the
+    // extension which makes all of the requisite changes to the object model.  When the singleton ApiProvider
+    // is destructed, all of the changes made during construction are reversed.
+    //
+    // Something is seriously amiss if there is already an ApiProvider at this point!
+    //
+    if (s_pProvider != nullptr)
+    {
+        throw std::logic_error("Internal error: ApiProvider singleton is already created");
+    }
+
+    s_pProvider = this;
+
+    //*************************************************
+    // Initialize our extension points.  These are classes which add new properties or namespaces to existing
+    // constructs within the debugger (e.g.: to "Debugger.Utility.*" or to the debugger's notion of a module)
+    //
+    // When these classes go away, the extensions are removed.
+    //
+
+    m_spSymbolBuilderNamespaceExtension = std::make_unique<SymbolBuilderNamespace>();
+    m_spModuleExtension = std::make_unique<ModuleExtension>();
+
+    //*************************************************
+    // Initialize our typed object models / factories.  These are classes which represent a binding between one
+    // of our objects (at the target composition level) and the data model.
+    //
+    // When these classes go away, the bindings are removed.
+    //
+    
+    //
+    // General:
+    //
+
+    m_spSymbolSetFactory = std::make_unique<SymbolSetObject>();
+    m_spTypesFactory = std::make_unique<TypesObject>();
+    m_spDataFactory = std::make_unique<DataObject>();
+
+    //
+    // Types:
+    //
+
+    m_spBasicTypeFactory = std::make_unique<BasicTypeObject>();
+    m_spUdtTypeFactory = std::make_unique<UdtTypeObject>();
+    m_spPointerTypeFactory = std::make_unique<PointerTypeObject>();
+    m_spArrayTypeFactory = std::make_unique<ArrayTypeObject>();
+    m_spTypedefTypeFactory = std::make_unique<TypedefTypeObject>();
+    m_spEnumTypeFactory = std::make_unique<EnumTypeObject>();
+
+    //
+    // Data:
+    //
+    
+    m_spGlobalDataFactory = std::make_unique<GlobalDataObject>();
+
+    //
+    // Other Symbols:
+    //
+
+    m_spFieldsFactory = std::make_unique<FieldsObject>();
+    m_spFieldFactory = std::make_unique<FieldObject>();
+    m_spBaseClassesFactory = std::make_unique<BaseClassesObject>();
+    m_spBaseClassFactory = std::make_unique<BaseClassObject>();
+    m_spEnumerantsFactory = std::make_unique<EnumerantsObject>();
+}
+
+ApiProvider::~ApiProvider()
+{
+    s_pProvider = nullptr;
+}
+
+//*************************************************
+// Namespace APIs:
+//
+
+Object SymbolBuilderNamespace::CreateSymbols(_In_ const Object& /*contextObject*/,
+                                             _In_ Object moduleArg)
+{
+    ModelObjectKind moduleArgKind = moduleArg.GetKind();
+
+    ULONG64 moduleBase = 0;
+    Object moduleObject;
+    switch(moduleArgKind)
+    {
+        case ObjectIntrinsic:
+        {
+            //
+            // There isn't a convenient C++ way to ask whether the intrinsic is a string, number, float,
+            // etc...  We can certainly try to cast and catch a throw; however, we'll just go down one level
+            // and see if it's unpackable as a 64-bit unsigned before trying the "convert to string"
+            //
+            VARIANT vtVal;
+            if (SUCCEEDED(moduleArg->GetIntrinsicValueAs(VT_UI8, &vtVal)))
+            {
+                moduleBase = vtVal.ullVal;
+            }
+
+            std::wstring moduleName = (std::wstring)moduleArg;
+
+            Object modules = Object::CurrentProcess().KeyValue(L"Modules");
+            moduleObject = modules[moduleName];
+            break;
+        }
+
+        default:
+        {
+            moduleObject = moduleArg;
+            break;
+        }
+    }
+
+    HostContext moduleContext;
+    if (moduleObject != nullptr)
+    {
+        moduleBase = (ULONG64)moduleObject.KeyValue(L"BaseAddress");
+        moduleContext = (HostContext)moduleObject;
+    }
+    else
+    {
+        moduleContext = HostContext::Current();
+    }
+
+    ComPtr<ISvcSymbolBuilderManager> spSymbolManager;
+    ComPtr<ISvcProcess> spProcess;
+    GetSymbolBuilderManager(moduleContext, &spSymbolManager, &spProcess);
+
+    ComPtr<SymbolBuilderProcess> spSymbolProcess;
+    CheckHr(spSymbolManager->TrackProcess(spProcess.Get(), &spSymbolProcess));
+
+    ComPtr<ISvcModule> spModule;
+    CheckHr(spSymbolManager->ModuleBaseToModule(spProcess.Get(), moduleBase, &spModule));
+
+    ULONG64 moduleKey;
+    CheckHr(spModule->GetKey(&moduleKey));
+
+    //
+    // Once we know what module we're trying to create symbol builder symbols for, check whether we have
+    // *ALREADY* done that for this particular module.  You can only do this once.
+    //
+    ComPtr<SymbolSet> spSymbolSet;
+    if (spSymbolProcess->TryGetSymbolsForModule(moduleKey, &spSymbolSet))
+    {
+        throw std::invalid_argument("module");
+    }
+
+    CheckHr(spSymbolProcess->CreateSymbolsForModule(spModule.Get(), moduleKey, &spSymbolSet));
+
+    SymbolSetObject& symbolSetFactory = ApiProvider::Get().GetSymbolSetFactory();
+    return symbolSetFactory.CreateInstance(spSymbolSet);
+}
+
+//*************************************************
+// Object Extensions (Module)
+//
+
+Object ModuleExtension::GetSymbolBuilderSymbols(_In_ const Object& moduleObject)
+{
+    HostContext moduleContext = (HostContext)moduleObject;
+
+    ComPtr<ISvcSymbolBuilderManager> spSymbolManager;
+    ComPtr<ISvcProcess> spProcess;
+    GetSymbolBuilderManager(moduleContext, &spSymbolManager, &spProcess);
+
+    ComPtr<SymbolBuilderProcess> spSymbolProcess;
+    CheckHr(spSymbolManager->TrackProcess(spProcess.Get(), &spSymbolProcess));
+
+    ULONG64 moduleBase = (ULONG64)moduleObject.KeyValue(L"BaseAddress");
+
+    ComPtr<ISvcModule> spModule;
+    CheckHr(spSymbolManager->ModuleBaseToModule(spProcess.Get(), moduleBase, &spModule));
+
+    ULONG64 moduleKey;
+    CheckHr(spModule->GetKey(&moduleKey));
+
+    ComPtr<SymbolSet> spSymbolSet;
+    if (!spSymbolProcess->TryGetSymbolsForModule(moduleKey, &spSymbolSet))
+    {
+        //
+        // Returning "no value" will mean that this property really isn't applicable for this object...  it has.
+        // no value.  The debugger's display engine will, by default, not display any properties which have
+        // no value.
+        //
+        return Object::CreateNoValue();
+    }
+
+    SymbolSetObject& symbolSetFactory = ApiProvider::Get().GetSymbolSetFactory();
+    return symbolSetFactory.CreateInstance(spSymbolSet);
+}
+
+//*************************************************
+// Symbol Set APIs:
+//
+
+Object SymbolSetObject::GetTypes(_In_ const Object& /*symbolSetObject*/,
+                                 _In_ ComPtr<SymbolSet>& spSymbolSet)
+{
+    TypesObject& typesFactory = ApiProvider::Get().GetTypesFactory();
+    return typesFactory.CreateInstance(spSymbolSet);
+}
+
+Object SymbolSetObject::GetData(_In_ const Object& /*symbolSetObject*/,
+                                _In_ ComPtr<SymbolSet>& spSymbolSet)
+{
+    DataObject& dataFactory = ApiProvider::Get().GetDataFactory();
+    return dataFactory.CreateInstance(spSymbolSet);
+}
+
+//*************************************************
+// General Symbol Helpers:
+//
+
+BaseTypeSymbol *SymbolObjectHelpers::UnboxType(_In_ SymbolSet *pSymbolSet, 
+                                               _In_ Object typeObject,
+                                               _In_ bool allowAutoCreations)
+
+{
+    //
+    // NOTE: Every raw assignment of pBaseType which holds a raw pointer from a ComPtr<> which will go out of 
+    //       scope is perfectly safe *BECAUSE* there is a guarantee that the symbol is held globally by the
+    //       symbol set in its index table.  No one could possibly delete it out of that table while this function
+    //       is executing.
+    //
+    BaseTypeSymbol *pBaseType = nullptr;
+    if (ApiProvider::Get().GetBasicTypeFactory().IsObjectInstance(typeObject))
+    {
+        ComPtr<BasicTypeSymbol> spBasicType = ApiProvider::Get().GetBasicTypeFactory().GetStoredInstance(typeObject);
+        pBaseType = spBasicType.Get();
+    }
+    else if (ApiProvider::Get().GetUdtTypeFactory().IsObjectInstance(typeObject))
+    {
+        ComPtr<UdtTypeSymbol> spUdtType = ApiProvider::Get().GetUdtTypeFactory().GetStoredInstance(typeObject);
+        pBaseType = spUdtType.Get();
+    }
+    else if (ApiProvider::Get().GetPointerTypeFactory().IsObjectInstance(typeObject))
+    {
+        ComPtr<PointerTypeSymbol> spPointerType = ApiProvider::Get().GetPointerTypeFactory().GetStoredInstance(typeObject);
+        pBaseType = spPointerType.Get();
+    }
+    else if (ApiProvider::Get().GetArrayTypeFactory().IsObjectInstance(typeObject))
+    {
+        ComPtr<ArrayTypeSymbol> spArrayType = ApiProvider::Get().GetArrayTypeFactory().GetStoredInstance(typeObject);
+        pBaseType = spArrayType.Get();
+    }
+    else if (ApiProvider::Get().GetTypedefTypeFactory().IsObjectInstance(typeObject))
+    {
+        ComPtr<TypedefTypeSymbol> spTypedefType = ApiProvider::Get().GetTypedefTypeFactory().GetStoredInstance(typeObject);
+        pBaseType = spTypedefType.Get();
+    }
+    else if (ApiProvider::Get().GetEnumTypeFactory().IsObjectInstance(typeObject))
+    {
+        ComPtr<EnumTypeSymbol> spEnumType = ApiProvider::Get().GetEnumTypeFactory().GetStoredInstance(typeObject);
+        pBaseType = spEnumType.Get();
+    }
+    else
+    {
+        std::wstring typeName = (std::wstring)typeObject;
+        ULONG64 typeId;
+        CheckHr(pSymbolSet->FindTypeByName(typeName, &typeId, &pBaseType, allowAutoCreations));
+    }
+
+    return pBaseType;
+}
+
+Object SymbolObjectHelpers::BoxRelatedType(_In_ BaseSymbol *pSymbol, _In_ ULONG64 typeId)
+{
+    BaseSymbol *pRelatedSymbol = pSymbol->InternalGetSymbolSet()->InternalGetSymbol(typeId);
+    if (pRelatedSymbol == nullptr || pRelatedSymbol->InternalGetKind() != SvcSymbolType)
+    {
+        throw std::runtime_error("unrecognized type");
+    }
+
+    return BoxType(static_cast<BaseTypeSymbol *>(pRelatedSymbol));
+}
+
+Object SymbolObjectHelpers::BoxType(_In_ BaseTypeSymbol *pSymbol)
+{
+    SvcSymbolTypeKind tk = pSymbol->InternalGetTypeKind();
+
+    Object typeObject;
+    switch(tk)
+    {
+        case SvcSymbolTypeIntrinsic:
+        {
+            BasicTypeSymbol *pBasicSymbol = static_cast<BasicTypeSymbol *>(pSymbol);
+            ComPtr<BasicTypeSymbol> spBasicSymbol = pBasicSymbol;
+            BasicTypeObject& basicTypeFactory = ApiProvider::Get().GetBasicTypeFactory();
+            typeObject = basicTypeFactory.CreateInstance(spBasicSymbol);
+            break;
+        }
+
+        case SvcSymbolTypeUDT:
+        {
+            UdtTypeSymbol *pUdtSymbol = static_cast<UdtTypeSymbol *>(pSymbol);
+            ComPtr<UdtTypeSymbol> spUdtSymbol = pUdtSymbol;
+            UdtTypeObject& udtTypeFactory = ApiProvider::Get().GetUdtTypeFactory();
+            typeObject = udtTypeFactory.CreateInstance(spUdtSymbol);
+            break;
+        }
+
+        case SvcSymbolTypePointer:
+        {
+            PointerTypeSymbol *pPointerSymbol = static_cast<PointerTypeSymbol *>(pSymbol);
+            ComPtr<PointerTypeSymbol> spPointerSymbol = pPointerSymbol;
+            PointerTypeObject& pointerTypeFactory = ApiProvider::Get().GetPointerTypeFactory();
+            typeObject = pointerTypeFactory.CreateInstance(spPointerSymbol);
+            break;
+        }
+
+        case SvcSymbolTypeArray:
+        {
+            ArrayTypeSymbol *pArraySymbol = static_cast<ArrayTypeSymbol *>(pSymbol);
+            ComPtr<ArrayTypeSymbol> spArraySymbol = pArraySymbol;
+            ArrayTypeObject& arrayTypeFactory = ApiProvider::Get().GetArrayTypeFactory();
+            typeObject = arrayTypeFactory.CreateInstance(spArraySymbol);
+            break;
+        }
+
+        case SvcSymbolTypeTypedef:
+        {
+            TypedefTypeSymbol *pTypedefSymbol = static_cast<TypedefTypeSymbol *>(pSymbol);
+            ComPtr<TypedefTypeSymbol> spTypedefSymbol = pTypedefSymbol;
+            TypedefTypeObject& typedefTypeFactory = ApiProvider::Get().GetTypedefTypeFactory();
+            typeObject = typedefTypeFactory.CreateInstance(spTypedefSymbol);
+            break;
+        }
+
+        case SvcSymbolTypeEnum:
+        {
+            EnumTypeSymbol *pEnumSymbol = static_cast<EnumTypeSymbol *>(pSymbol);
+            ComPtr<EnumTypeSymbol> spEnumSymbol = pEnumSymbol;
+            EnumTypeObject& enumTypeFactory = ApiProvider::Get().GetEnumTypeFactory();
+            typeObject = enumTypeFactory.CreateInstance(spEnumSymbol);
+            break;
+        }
+
+        default:
+            throw std::runtime_error("unrecognized type");
+    }
+
+    return typeObject;
+}
+
+Object SymbolObjectHelpers::BoxSymbol(_In_ BaseSymbol *pSymbol)
+{
+    Object symbolObject;
+    switch(pSymbol->InternalGetKind())
+    {
+        case SvcSymbolType:
+            return BoxType(static_cast<BaseTypeSymbol *>(pSymbol));
+
+        case SvcSymbolField:
+        {
+            FieldSymbol *pFieldSymbol = static_cast<FieldSymbol *>(pSymbol);
+            ComPtr<FieldSymbol> spFieldSymbol = pFieldSymbol;
+            FieldObject& fieldFactory = ApiProvider::Get().GetFieldFactory();
+            symbolObject = fieldFactory.CreateInstance(spFieldSymbol);
+            break;
+        }
+
+        case SvcSymbolBaseClass:
+        {
+            BaseClassSymbol *pBaseClassSymbol = static_cast<BaseClassSymbol *>(pSymbol);
+            ComPtr<BaseClassSymbol> spBaseClassSymbol = pBaseClassSymbol;
+            BaseClassObject& baseClassFactory = ApiProvider::Get().GetBaseClassFactory();
+            symbolObject = baseClassFactory.CreateInstance(spBaseClassSymbol);
+            break;
+        }
+
+        default:
+            throw std::runtime_error("unrecognized symbol");
+    }
+
+    return symbolObject;
+}
+
+//*************************************************
+// Types APIs:
+
+void TypesObject::AddBasicCTypes(_In_ const Object& /*typesObjec*/, _In_ ComPtr<SymbolSet>& spSymbolSet)
+{
+    SymbolSet *pSymbolSet = spSymbolSet.Get();
+    CheckHr(pSymbolSet->AddBasicCTypes());
+}
+
+Object TypesObject::Create(_In_ const Object& /*typesObject*/, 
+                           _In_ ComPtr<SymbolSet>& spSymbolSet,
+                           _In_ std::wstring typeName,
+                           _In_ std::optional<std::wstring> qualifiedTypeName)
+{
+    SymbolSet *pSymbolSet = spSymbolSet.Get();
+
+    PCWSTR pwszTypeName = typeName.c_str();
+    PCWSTR pwszQualifiedName = (qualifiedTypeName.has_value() ? qualifiedTypeName.value().c_str() : nullptr);
+
+    ComPtr<UdtTypeSymbol> spUdt;
+    CheckHr(MakeAndInitialize<UdtTypeSymbol>(&spUdt, pSymbolSet, 0, pwszTypeName, pwszQualifiedName));
+
+    UdtTypeObject& udtTypeFactory = ApiProvider::Get().GetUdtTypeFactory();
+    return udtTypeFactory.CreateInstance(spUdt);
+}
+
+Object TypesObject::CreatePointer(_In_ const Object& /*typesObject*/,
+                                  _In_ ComPtr<SymbolSet>& spSymbolSet,
+                                  _In_ Object pointedToType)
+{
+    BaseTypeSymbol *pPointedToType = UnboxType(spSymbolSet.Get(), pointedToType);
+
+    ComPtr<PointerTypeSymbol> spPointer;
+    CheckHr(MakeAndInitialize<PointerTypeSymbol>(&spPointer, 
+                                                 spSymbolSet.Get(), 
+                                                 pPointedToType->InternalGetId(), 
+                                                 SvcSymbolPointerStandard /* @TODO: */));
+
+    PointerTypeObject &pointerTypeFactory = ApiProvider::Get().GetPointerTypeFactory();
+    return pointerTypeFactory.CreateInstance(spPointer);
+}
+
+Object TypesObject::CreateArray(_In_ const Object& /*typesObject*/,
+                                _In_ ComPtr<SymbolSet>& spSymbolSet,
+                                _In_ Object arrayOfType,
+                                _In_ ULONG64 arrayDim)
+{
+    BaseTypeSymbol *pArrayOfType = UnboxType(spSymbolSet.Get(), arrayOfType);
+
+    ComPtr<ArrayTypeSymbol> spArray;
+    CheckHr(MakeAndInitialize<ArrayTypeSymbol>(&spArray,
+                                               spSymbolSet.Get(),
+                                               pArrayOfType->InternalGetId(),
+                                               arrayDim));
+
+    ArrayTypeObject &arrayTypeFactory = ApiProvider::Get().GetArrayTypeFactory();
+    return arrayTypeFactory.CreateInstance(spArray);
+}
+
+Object TypesObject::CreateTypedef(_In_ const Object& /*typesObject*/,
+                                  _In_ ComPtr<SymbolSet>& spSymbolSet,
+                                  _In_ std::wstring typeName,
+                                  _In_ Object typedefOfType,
+                                  _In_ std::optional<std::wstring> qualifiedTypeName)
+{
+    BaseTypeSymbol *pTypedefOfType = UnboxType(spSymbolSet.Get(), typedefOfType);
+
+    PCWSTR pwszTypeName = typeName.c_str();
+    PCWSTR pwszQualifiedName = (qualifiedTypeName.has_value() ? qualifiedTypeName.value().c_str() : nullptr);
+
+    ComPtr<TypedefTypeSymbol> spTypedef;
+    CheckHr(MakeAndInitialize<TypedefTypeSymbol>(&spTypedef, 
+                                                 spSymbolSet.Get(), 
+                                                 pTypedefOfType->InternalGetId(),
+                                                 0, 
+                                                 pwszTypeName,
+                                                 pwszQualifiedName));
+
+    TypedefTypeObject &typedefTypeFactory = ApiProvider::Get().GetTypedefTypeFactory();
+    return typedefTypeFactory.CreateInstance(spTypedef);
+}
+
+Object TypesObject::CreateEnum(_In_ const Object& /*typesObject*/,
+                               _In_ ComPtr<SymbolSet>& spSymbolSet,
+                               _In_ std::wstring typeName,
+                               _In_ std::optional<Object> enumBasicType,
+                               _In_ std::optional<std::wstring> qualifiedTypeName)
+{
+    //
+    // If there is no value for the basic type (it's not provided), default to "int" which is the
+    // standard C default.
+    //
+    ULONG64 basicTypeId;
+    if (enumBasicType.has_value())
+    {
+        BaseTypeSymbol *pEnumBasicType = UnboxType(spSymbolSet.Get(), enumBasicType.value());
+        basicTypeId = pEnumBasicType->InternalGetId();
+    }
+    else
+    {
+        CheckHr(spSymbolSet->FindTypeByName(L"int", &basicTypeId, nullptr, false));
+    }
+
+    PCWSTR pwszTypeName = typeName.c_str();
+    PCWSTR pwszQualifiedName = (qualifiedTypeName.has_value() ? qualifiedTypeName.value().c_str() : nullptr);
+
+    ComPtr<EnumTypeSymbol> spEnum;
+    CheckHr(MakeAndInitialize<EnumTypeSymbol>(&spEnum, 
+                                              spSymbolSet.Get(), 
+                                              basicTypeId,
+                                              0, 
+                                              pwszTypeName,
+                                              pwszQualifiedName));
+
+    EnumTypeObject &enumTypeFactory = ApiProvider::Get().GetEnumTypeFactory();
+    return enumTypeFactory.CreateInstance(spEnum);
+}
+
+std::experimental::generator<Object> TypesObject::GetIterator(_In_ const Object& /*typesObject*/,
+                                                              _In_ ComPtr<SymbolSet>& spSymbolSet)
+{
+    //
+    // We must take **GREAT CARE** with what we touch and how we iterate.  After a co_yield, the state
+    // of things may have drastically changed.  We must refetch things and only rely upon positional
+    // counters!
+    //
+    size_t cur = 0;
+    for(;;)
+    {
+        auto&& globalSymbols = spSymbolSet->InternalGetGlobalSymbols();
+        if (cur >= globalSymbols.size())
+        {
+            break;
+        }
+
+        ULONG64 nextGlobal = globalSymbols[cur];
+        ++cur;
+
+        BaseSymbol *pNextSymbol = spSymbolSet->InternalGetSymbol(nextGlobal);
+        if (pNextSymbol->InternalGetKind() != SvcSymbolType)
+        {
+            continue;
+        }
+
+        BaseTypeSymbol *pNextType = static_cast<BaseTypeSymbol *>(pNextSymbol);
+        Object typeObject = BoxType(pNextType);
+        co_yield typeObject;
+    }
+}
+
+//*************************************************
+// Base Symbols API:
+//
+
+template<typename TSym>
+Object BaseSymbolObject<TSym>::GetName(_In_ const Object& /*symbolObject*/, _In_ ComPtr<TSym>& spSymbol)
+{
+    if (spSymbol->InternalGetName().empty())
+    {
+        return Object::CreateNoValue();
+    }
+
+    return spSymbol->InternalGetName();
+}
+
+template<typename TSym>
+Object BaseSymbolObject<TSym>::GetQualifiedName(_In_ const Object& /*symbolObject*/, _In_ ComPtr<TSym>& spSymbol)
+{
+    if (spSymbol->InternalGetQualifiedName().empty())
+    {
+        return Object::CreateNoValue();
+    }
+
+    return spSymbol->InternalGetQualifiedName();
+}
+
+template<typename TSym>
+Object BaseSymbolObject<TSym>::GetParent(_In_ const Object& /*symbolObject*/, _In_ ComPtr<TSym>& spSymbol)
+{
+    BaseSymbol *pParentSymbol = spSymbol->InternalGetSymbolSet()->InternalGetSymbol(spSymbol->InternalGetParentId());
+    if (pParentSymbol == nullptr)
+    {
+        return Object::CreateNoValue();
+    }
+
+    return BoxSymbol(pParentSymbol);
+}
+
+//*************************************************
+// Base Types APIs:
+//
+
+template<typename TType>
+ULONG64 BaseTypeObject<TType>::GetSize(_In_ const Object& /*typeObject*/, _In_ ComPtr<TType>& spTypeSymbol)
+{
+    return spTypeSymbol->InternalGetTypeSize();
+}
+
+template<typename TType>
+ULONG64 BaseTypeObject<TType>::GetAlignment(_In_ const Object& /*typeObject*/, _In_ ComPtr<TType>& spTypeSymbol)
+{
+    return spTypeSymbol->InternalGetTypeAlignment();
+}
+
+template<typename TType>
+std::wstring BaseTypeObject<TType>::ToString(_In_ const Object& /*typeObject*/,
+                                             _In_ ComPtr<TType>& spTypeSymbol,
+                                             _In_ const Metadata& /*metadata*/)
+{
+    std::wstring const& name = spTypeSymbol->InternalGetQualifiedName();
+
+    wchar_t buf[512];
+    swprintf_s(buf, ARRAYSIZE(buf), L"%s: %s ( size = %d, align = %d )",
+               m_pwszConvTag,
+               name.empty() ? L"<Unknown>" : name.c_str(),
+               (ULONG)spTypeSymbol->InternalGetTypeSize(),
+               (ULONG)spTypeSymbol->InternalGetTypeAlignment());
+
+    return (std::wstring)buf;
+}
+
+template<typename TType>
+void BaseTypeObject<TType>::Delete(_In_ const Object& /*typeObject*/,
+                                   _In_ ComPtr<TType>& spTypeSymbol)
+{
+    CheckHr(spTypeSymbol->Delete());
+}
+
+//*************************************************
+// UDT APIs:
+//
+
+Object UdtTypeObject::GetBaseClasses(_In_ const Object& /*typeObject*/,
+                                     _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol)
+{
+    BaseClassesObject& baseClassesFactory = ApiProvider::Get().GetBaseClassesFactory();
+    return baseClassesFactory.CreateInstance(spUdtTypeSymbol);
+}
+
+Object UdtTypeObject::GetFields(_In_ const Object& /*typeObject*/,
+                                _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol)
+{
+    FieldsObject& fieldsFactory = ApiProvider::Get().GetFieldsFactory();
+    return fieldsFactory.CreateInstance(spUdtTypeSymbol);
+}
+
+//*************************************************
+// Pointer APIs:
+//
+
+Object PointerTypeObject::GetBaseType(_In_ const Object& /*pointerTypeObject*/,
+                                      _In_ ComPtr<PointerTypeSymbol>& spPointerTypeSymbol)
+{
+    return BoxRelatedType(spPointerTypeSymbol.Get(), spPointerTypeSymbol->InternalGetPointerToTypeId());
+}
+
+//*************************************************
+// Array APIs:
+//
+
+Object ArrayTypeObject::GetBaseType(_In_ const Object& /*arrayTypeObject*/,
+                                    _In_ ComPtr<ArrayTypeSymbol>& spArrayTypeSymbol)
+{
+    return BoxRelatedType(spArrayTypeSymbol.Get(), spArrayTypeSymbol->InternalGetArrayOfTypeId());
+}
+
+ULONG64 ArrayTypeObject::GetArraySize(_In_ const Object& /*arrayTypeObject*/, 
+                                      _In_ ComPtr<ArrayTypeSymbol>& spArraySymbol)
+{
+    return spArraySymbol->InternalGetArraySize();
+}
+
+//*************************************************
+// Typedef APIs:
+//
+
+Object TypedefTypeObject::GetBaseType(_In_ const Object& /*typedefTypeObject*/,
+                                      _In_ ComPtr<TypedefTypeSymbol>& spTypedefTypeSymbol)
+{
+    return BoxRelatedType(spTypedefTypeSymbol.Get(), spTypedefTypeSymbol->InternalGetTypedefOfTypeId());
+}
+
+//*************************************************
+// Enum APIs:
+//
+
+Object EnumTypeObject::GetBaseType(_In_ const Object& /*enumTypeObject*/,
+                                   _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol)
+{
+    return BoxRelatedType(spEnumTypeSymbol.Get(), spEnumTypeSymbol->InternalGetEnumBasicTypeId());
+}
+
+Object EnumTypeObject::GetEnumerants(_In_ const Object& /*enumObject*/,
+                                     _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol)
+{
+    EnumerantsObject& enumerantsFactory = ApiProvider::Get().GetEnumerantsFactory();
+    return enumerantsFactory.CreateInstance(spEnumTypeSymbol);
+}
+
+//*************************************************
+// Fields APIs:
+//
+
+std::experimental::generator<Object> FieldsObject::GetIterator(_In_ const Object& /*fieldsObject*/,
+                                                               _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol)
+{
+    //
+    // We must take **GREAT CARE** with what we touch and how we iterate.  After a co_yield, the state
+    // of things may have drastically changed.  We must refetch things and only rely upon positional
+    // counters!
+    //
+    size_t cur = 0;
+    for(;;)
+    {
+        auto&& children = spUdtTypeSymbol->InternalGetChildren();
+        if (cur >= children.size())
+        {
+            break;
+        }
+
+        ULONG64 nextChild = children[cur];
+        ++cur;
+
+        BaseSymbol *pNextSymbol = spUdtTypeSymbol->InternalGetSymbolSet()->InternalGetSymbol(nextChild);
+        if (pNextSymbol->InternalGetKind() != SvcSymbolField)
+        {
+            continue;
+        }
+
+        FieldSymbol *pNextField = static_cast<FieldSymbol *>(pNextSymbol);
+        ComPtr<FieldSymbol> spNextField = pNextField;
+        FieldObject& fieldFactory = ApiProvider::Get().GetFieldFactory();
+        Object fieldObj = fieldFactory.CreateInstance(spNextField);
+        co_yield fieldObj;
+    }
+}
+
+Object FieldsObject::Add(_In_ const Object& /*fieldsObject*/,
+                         _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol,
+                         _In_ std::wstring fieldName,
+                         _In_ Object fieldType,
+                         _In_ std::optional<ULONG64> fieldOffset)
+{
+    SymbolSet *pSymbolSet = spUdtTypeSymbol->InternalGetSymbolSet();
+
+    ULONG64 fieldOffsetToUse = fieldOffset.value_or(UdtPositionalSymbol::AutomaticAppendLayout);
+    ULONG64 fieldTypeId = 0;
+
+    UdtTypeObject& udtTypeFactory = ApiProvider::Get().GetUdtTypeFactory();
+    if (udtTypeFactory.IsObjectInstance(fieldType))
+    {
+        ComPtr<UdtTypeSymbol> spFieldType_Udt = udtTypeFactory.GetStoredInstance(fieldType);
+        fieldTypeId = spFieldType_Udt->InternalGetId();
+    }
+    else
+    {
+        std::wstring fieldTypeName = (std::wstring)fieldType;
+        fieldTypeId = pSymbolSet->InternalGetSymbolIdByName(fieldTypeName);
+    }
+
+    BaseTypeSymbol *pFieldType = UnboxType(pSymbolSet, fieldType);
+
+    ComPtr<FieldSymbol> spField;
+    CheckHr(MakeAndInitialize<FieldSymbol>(&spField, 
+                                          pSymbolSet,
+                                          spUdtTypeSymbol->InternalGetId(),
+                                          fieldOffsetToUse,
+                                          pFieldType->InternalGetId(),
+                                          fieldName.c_str()));
+
+    FieldObject& fieldFactory = ApiProvider::Get().GetFieldFactory();
+    return fieldFactory.CreateInstance(spField);
+}
+
+//*************************************************
+// Enumerants APIs:
+//
+
+std::experimental::generator<Object> EnumerantsObject::GetIterator(_In_ const Object& /*enumerantsObject*/,
+                                                                   _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol)
+{
+    //
+    // We must take **GREAT CARE** with what we touch and how we iterate.  After a co_yield, the state
+    // of things may have drastically changed.  We must refetch things and only rely upon positional
+    // counters!
+    //
+    size_t cur = 0;
+    for(;;)
+    {
+        auto&& children = spEnumTypeSymbol->InternalGetChildren();
+        if (cur >= children.size())
+        {
+            break;
+        }
+
+        ULONG64 nextChild = children[cur];
+        ++cur;
+
+        BaseSymbol *pNextSymbol = spEnumTypeSymbol->InternalGetSymbolSet()->InternalGetSymbol(nextChild);
+        if (pNextSymbol->InternalGetKind() != SvcSymbolField)
+        {
+            continue;
+        }
+
+        FieldSymbol *pNextField = static_cast<FieldSymbol *>(pNextSymbol);
+        ComPtr<FieldSymbol> spNextField = pNextField;
+        FieldObject& fieldFactory = ApiProvider::Get().GetFieldFactory();
+        Object fieldObj = fieldFactory.CreateInstance(spNextField);
+        co_yield fieldObj;
+    }
+}
+
+Object EnumerantsObject::Add(_In_ const Object& /*enumObject*/,
+                             _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol,
+                             _In_ std::wstring enumerantName,
+                             _In_ std::optional<Object> enumerantValue)
+{
+    SymbolSet *pSymbolSet = spEnumTypeSymbol->InternalGetSymbolSet();
+
+    //
+    // We know the enum's packing type as a VARTYPE.  Just ask the underlying data model to convert the
+    // value to our packing.  If it can't be done (because it's an overflow, etc...) just throw.
+    //
+    // NOTE: Because of the limited variant support, we do *NOT* need to VariantInit/VariantClear/etc...
+    //
+    // If there is no value, consider it an auto-increment enumerant (ala an unvalued "C enum" enumerant)
+    //
+    VARIANT vtEnumerantValue;
+    vtEnumerantValue.vt = VT_EMPTY;
+
+    if (enumerantValue.has_value())
+    {
+        Object val = enumerantValue.value();
+        CheckHr(val->GetIntrinsicValueAs(spEnumTypeSymbol->InternalGetEnumValuePacking(), &vtEnumerantValue));
+    }
+
+    ComPtr<FieldSymbol> spField;
+    CheckHr(MakeAndInitialize<FieldSymbol>(&spField, 
+                                          pSymbolSet,
+                                          spEnumTypeSymbol->InternalGetId(),
+                                          0,
+                                          &vtEnumerantValue,
+                                          enumerantName.c_str()));
+
+    FieldObject& fieldFactory = ApiProvider::Get().GetFieldFactory();
+    return fieldFactory.CreateInstance(spField);
+}
+
+//*************************************************
+// Field APIs:
+//
+
+std::wstring FieldObject::ToString(_In_ const Object& /*fieldObject*/,
+                                   _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                                   _In_ const Metadata& /*metadata*/)
+{
+    wchar_t buf[512];
+
+    std::wstring const& fieldName = spFieldSymbol->InternalGetName();
+
+    ULONG64 fieldTypeId = spFieldSymbol->InternalGetSymbolTypeId();
+
+    if (fieldTypeId == 0)
+    {
+        //
+        // The only way this is legal is if it is a constant valued enumerant!
+        //
+        std::wstring value = ValueToString(spFieldSymbol->InternalGetSymbolValue());
+
+        swprintf_s(buf, ARRAYSIZE(buf), L"Enumerant: %s (value = %s)",
+                   fieldName.empty() ? L"<Unknown>" : fieldName.c_str(),
+                   value.c_str());
+    }
+    else if (spFieldSymbol->InternalIsConstantValue())
+    {
+        BaseSymbol *pFieldTypeSymbol = spFieldSymbol->InternalGetSymbolSet()->InternalGetSymbol(fieldTypeId);
+        std::wstring const& fieldTypeName = pFieldTypeSymbol->InternalGetQualifiedName();
+        std::wstring value = ValueToString(spFieldSymbol->InternalGetSymbolValue());
+
+        swprintf_s(buf, ARRAYSIZE(buf), L"Field: %s (type = '%s', value = %s )",
+                   fieldName.empty() ? L"<Unknown>" : fieldName.c_str(),
+                   fieldTypeName.empty() ? L"<Unknown>" : fieldTypeName.c_str(),
+                   value.c_str());
+
+    }
+    else
+    {
+        BaseSymbol *pFieldTypeSymbol = spFieldSymbol->InternalGetSymbolSet()->InternalGetSymbol(fieldTypeId);
+        std::wstring const& fieldTypeName = pFieldTypeSymbol->InternalGetQualifiedName();
+
+        swprintf_s(buf, ARRAYSIZE(buf), L"Field: %s ( type = '%s', offset = %d )",
+                   fieldName.empty() ? L"<Unknown>" : fieldName.c_str(),
+                   fieldTypeName.empty() ? L"<Unknown>" : fieldTypeName.c_str(),
+                   (ULONG)spFieldSymbol->InternalGetActualSymbolOffset());
+    }
+
+    return (std::wstring)buf;
+}
+
+void FieldObject::Delete(_In_ const Object& /*fieldObject*/,
+                         _In_ ComPtr<FieldSymbol>& spFieldSymbol)
+{
+    CheckHr(spFieldSymbol->Delete());
+}
+
+void FieldObject::MoveBefore(_In_ const Object& /*fieldObject*/, _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                             _In_ Object beforeObj)
+{
+    ULONG64 pos = 0;
+
+    //
+    // The 'beforeObj' may be legitimately another field *OR* it may be a positional index of the field
+    // within the list of children.  Handle both.
+    //
+    FieldObject& fieldFactory = ApiProvider::Get().GetFieldFactory();
+    if (fieldFactory.IsObjectInstance(beforeObj))
+    {
+        ComPtr<FieldSymbol> spFieldSymbol = fieldFactory.GetStoredInstance(beforeObj);
+
+        SymbolSet *pSymbolSet = spFieldSymbol->InternalGetSymbolSet();
+        BaseSymbol *pParentSymbol = pSymbolSet->InternalGetSymbol(spFieldSymbol->InternalGetParentId());
+        if (pParentSymbol == nullptr)
+        {
+            throw std::runtime_error("cannot rearrange an orphan field");
+        }
+
+        CheckHr(pParentSymbol->GetChildPosition(spFieldSymbol->InternalGetId(), &pos));
+    }
+    else
+    {
+        pos = (ULONG64)beforeObj;
+    }
+
+    CheckHr(spFieldSymbol->MoveToBefore(pos));
+}
+
+std::optional<bool> FieldObject::GetIsAutomaticLayout(_In_ const Object& /*fieldObject*/, _In_ ComPtr<FieldSymbol>& spFieldSymbol)
+{
+    //
+    // This does not apply to constant valued fields which are not enumerants.
+    //
+    std::optional<bool> result;
+    if (spFieldSymbol->InternalIsConstantValue() && !spFieldSymbol->InternalIsEnumerant())
+    {
+        return result;
+    }
+
+    result = (spFieldSymbol->InternalIsAutomaticLayout() || spFieldSymbol->InternalIsIncreasingConstant());
+    return result;
+}
+
+void FieldObject::SetIsAutomaticLayout(_In_ const Object& /*fieldObject*/,
+                                       _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                                       _In_ bool isAutomaticLayout)
+{
+    //
+    // This does not apply to constant valued fields which are not enumerants.
+    //
+    if (spFieldSymbol->InternalIsConstantValue() && !spFieldSymbol->InternalIsEnumerant())
+    {
+        throw std::runtime_error("cannot change layout of constant valued field");
+    }
+
+    switch(spFieldSymbol->InternalGetSymbolOffset())
+    {
+        default:
+        case UdtPositionalSymbol::AutomaticAppendLayout:
+        {
+            ULONG64 actualOffset = spFieldSymbol->InternalGetActualSymbolOffset();
+            CheckHr(spFieldSymbol->InternalSetSymbolOffset(isAutomaticLayout ? UdtPositionalSymbol::AutomaticAppendLayout
+                                                                             : actualOffset));
+            break;
+        }
+
+        case UdtPositionalSymbol::ConstantValue:
+        case UdtPositionalSymbol::AutomaticIncreaseConstantValue:
+        {
+            CheckHr(spFieldSymbol->InternalSetSymbolOffset(isAutomaticLayout ? UdtPositionalSymbol::AutomaticIncreaseConstantValue
+                                                                             : UdtPositionalSymbol::ConstantValue));
+            break;
+        }
+    }
+}
+
+std::optional<ULONG64> FieldObject::GetOffset(_In_ const Object& /*fieldObject*/, _In_ ComPtr<FieldSymbol>& spFieldSymbol)
+{
+    std::optional<ULONG64> result;
+    
+    if (!spFieldSymbol->InternalIsConstantValue())
+    {
+        result = spFieldSymbol->InternalGetActualSymbolOffset();
+    }
+    return result;
+}
+
+void FieldObject::SetOffset(_In_ const Object& /*fieldObject*/, _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                            _In_ ULONG64 fieldOffset)
+{
+    if (spFieldSymbol->InternalIsAutomaticLayout())
+    {
+        throw std::runtime_error("cannot set field offset of a field which is automatic layout");
+    }
+    else if (spFieldSymbol->InternalIsConstantValue())
+    {
+        throw std::runtime_error("cannot set field offset of a field which is constnat value");
+    }
+
+    CheckHr(spFieldSymbol->InternalSetSymbolOffset(fieldOffset));
+}
+
+Object FieldObject::GetType(_In_ const Object& /*fieldObject*/, _In_ ComPtr<FieldSymbol>& spFieldSymbol)
+{
+    if (spFieldSymbol->InternalGetSymbolTypeId() == 0)
+    {
+        return Object::CreateNoValue();
+    }
+    
+    return BoxRelatedType(spFieldSymbol.Get(), spFieldSymbol->InternalGetSymbolTypeId());
+}
+
+void FieldObject::SetType(_In_ const Object& /*fieldObject*/, _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                          _In_ Object fieldType)
+{
+    if (spFieldSymbol->InternalGetSymbolTypeId() == 0)
+    {
+        throw std::runtime_error("cannot set explicit type of an enumerant");
+    }
+
+    BaseTypeSymbol *pNewFieldType = UnboxType(spFieldSymbol->InternalGetSymbolSet(),
+                                              fieldType);
+
+    CheckHr(spFieldSymbol->InternalSetSymbolTypeId(pNewFieldType->InternalGetId()));
+}
+
+//*************************************************
+// Base Classes APIs:
+//
+
+std::experimental::generator<Object> BaseClassesObject::GetIterator(_In_ const Object& /*baseClassesObject*/,
+                                                                    _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol)
+{
+    //
+    // We must take **GREAT CARE** with what we touch and how we iterate.  After a co_yield, the state
+    // of things may have drastically changed.  We must refetch things and only rely upon positional
+    // counters!
+    //
+    size_t cur = 0;
+    for(;;)
+    {
+        auto&& children = spUdtTypeSymbol->InternalGetChildren();
+        if (cur >= children.size())
+        {
+            break;
+        }
+
+        ULONG64 nextChild = children[cur];
+        ++cur;
+
+        BaseSymbol *pNextSymbol = spUdtTypeSymbol->InternalGetSymbolSet()->InternalGetSymbol(nextChild);
+        if (pNextSymbol->InternalGetKind() != SvcSymbolBaseClass)
+        {
+            continue;
+        }
+
+        BaseClassSymbol *pNextBaseClass = static_cast<BaseClassSymbol *>(pNextSymbol);
+        ComPtr<BaseClassSymbol> spNextBaseClass = pNextBaseClass;
+        BaseClassObject& baseClassFactory = ApiProvider::Get().GetBaseClassFactory();
+        Object baseClassObj = baseClassFactory.CreateInstance(spNextBaseClass);
+        co_yield baseClassObj;
+    }
+}
+
+Object BaseClassesObject::Add(_In_ const Object& /*fieldsObject*/,
+                              _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol,
+                              _In_ Object baseClassType,
+                              _In_ std::optional<ULONG64> baseClassOffset)
+{
+    SymbolSet *pSymbolSet = spUdtTypeSymbol->InternalGetSymbolSet();
+
+    ULONG64 baseClassOffsetToUse = baseClassOffset.value_or(UdtPositionalSymbol::AutomaticAppendLayout);
+    ULONG64 baseClassTypeId = 0;
+
+    UdtTypeObject& udtTypeFactory = ApiProvider::Get().GetUdtTypeFactory();
+    if (udtTypeFactory.IsObjectInstance(baseClassType))
+    {
+        ComPtr<UdtTypeSymbol> spBaseClassType_Udt = udtTypeFactory.GetStoredInstance(baseClassType);
+        baseClassTypeId = spBaseClassType_Udt->InternalGetId();
+    }
+    else
+    {
+        std::wstring baseClassTypeName = (std::wstring)baseClassType;
+        baseClassTypeId = pSymbolSet->InternalGetSymbolIdByName(baseClassTypeName);
+    }
+
+    BaseSymbol *pBaseClassTypeSymbol = pSymbolSet->InternalGetSymbol(baseClassTypeId);
+    if (pBaseClassTypeSymbol == nullptr || pBaseClassTypeSymbol->InternalGetKind() != SvcSymbolType)
+    {
+        throw std::invalid_argument("baseClassType");
+    }
+
+    BaseTypeSymbol *pBaseClassType = static_cast<BaseTypeSymbol *>(pBaseClassTypeSymbol);
+    if (pBaseClassType->InternalGetTypeKind() != SvcSymbolTypeUDT)
+    {
+        throw std::invalid_argument("baseClassType");
+    }
+
+    ComPtr<BaseClassSymbol> spBaseClass;
+    CheckHr(MakeAndInitialize<BaseClassSymbol>(&spBaseClass, 
+                                               pSymbolSet,
+                                               spUdtTypeSymbol->InternalGetId(),
+                                               baseClassOffsetToUse,
+                                               baseClassTypeId));
+
+    BaseClassObject& baseClassFactory = ApiProvider::Get().GetBaseClassFactory();
+    return baseClassFactory.CreateInstance(spBaseClass);
+}
+
+//*************************************************
+// Base Class APIs:
+//
+
+std::wstring BaseClassObject::ToString(_In_ const Object& /*baseClassObject*/,
+                                       _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                                       _In_ const Metadata& /*metadata*/)
+{
+    ULONG64 baseClassTypeId = spBaseClassSymbol->InternalGetSymbolTypeId();
+    BaseSymbol *pBaseClassTypeSymbol = spBaseClassSymbol->InternalGetSymbolSet()->InternalGetSymbol(baseClassTypeId);
+
+    std::wstring const& baseClassTypeName = pBaseClassTypeSymbol->InternalGetQualifiedName();
+
+    wchar_t buf[512];
+    swprintf_s(buf, ARRAYSIZE(buf), L"Base Class: ( type = '%s', offset = %d )",
+               baseClassTypeName.empty() ? L"<Unknown>" : baseClassTypeName.c_str(),
+               (ULONG)spBaseClassSymbol->InternalGetActualSymbolOffset());
+
+    return (std::wstring)buf;
+}
+
+void BaseClassObject::Delete(_In_ const Object& /*baseClassObject*/,
+                             _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol)
+{
+    CheckHr(spBaseClassSymbol->Delete());
+}
+
+void BaseClassObject::MoveBefore(_In_ const Object& /*baseClassObject*/, 
+                                 _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                                 _In_ Object beforeObj)
+{
+    ULONG64 pos = 0;
+
+    //
+    // The 'beforeObj' may be legitimately another base class *OR* it may be a positional index of the base class
+    // within the list of children.  Handle both.
+    //
+    BaseClassObject& baseClassFactory = ApiProvider::Get().GetBaseClassFactory();
+    if (baseClassFactory.IsObjectInstance(beforeObj))
+    {
+        ComPtr<BaseClassSymbol> spBaseClassSymbol = baseClassFactory.GetStoredInstance(beforeObj);
+
+        SymbolSet *pSymbolSet = spBaseClassSymbol->InternalGetSymbolSet();
+        BaseSymbol *pParentSymbol = pSymbolSet->InternalGetSymbol(spBaseClassSymbol->InternalGetParentId());
+        if (pParentSymbol == nullptr)
+        {
+            throw std::runtime_error("cannot rearrange an orphan base class");
+        }
+
+        CheckHr(pParentSymbol->GetChildPosition(spBaseClassSymbol->InternalGetId(), &pos));
+    }
+    else
+    {
+        pos = (ULONG64)beforeObj;
+    }
+
+    CheckHr(spBaseClassSymbol->MoveToBefore(pos));
+}
+
+bool BaseClassObject::GetIsAutomaticLayout(_In_ const Object& /*baseClassObject*/, 
+                                           _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol)
+{
+    ULONG64 symOffset = spBaseClassSymbol->InternalGetSymbolOffset();
+    return (symOffset == UdtPositionalSymbol::AutomaticAppendLayout);
+}
+
+void BaseClassObject::SetIsAutomaticLayout(_In_ const Object& /*baseClassObject*/,
+                                           _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                                           _In_ bool isAutomaticLayout)
+{
+    ULONG64 actualOffset = spBaseClassSymbol->InternalGetActualSymbolOffset();
+    CheckHr(spBaseClassSymbol->InternalSetSymbolOffset(isAutomaticLayout ? UdtPositionalSymbol::AutomaticAppendLayout
+                                                                         : actualOffset));
+}
+
+ULONG64 BaseClassObject::GetOffset(_In_ const Object& /*baseClassObject*/, 
+                                   _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol)
+{
+    return spBaseClassSymbol->InternalGetActualSymbolOffset();
+}
+
+void BaseClassObject::SetOffset(_In_ const Object& /*baseClassObject*/, 
+                                _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                                _In_ ULONG64 baseClassOffset)
+{
+    if (spBaseClassSymbol->InternalGetSymbolOffset() == UdtPositionalSymbol::AutomaticAppendLayout)
+    {
+        throw std::runtime_error("cannot set base class offset of a base class which is automatic layout");
+    }
+
+    CheckHr(spBaseClassSymbol->InternalSetSymbolOffset(baseClassOffset));
+}
+
+Object BaseClassObject::GetType(_In_ const Object& /*baseClassObject*/, 
+                                _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol)
+{
+    return BoxRelatedType(spBaseClassSymbol.Get(), spBaseClassSymbol->InternalGetSymbolTypeId());
+}
+
+void BaseClassObject::SetType(_In_ const Object& /*baseClassObject*/, 
+                              _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                              _In_ Object baseClassType)
+{
+    BaseTypeSymbol *pNewBaseClassType = UnboxType(spBaseClassSymbol->InternalGetSymbolSet(),
+                                                  baseClassType);
+
+    CheckHr(spBaseClassSymbol->InternalSetSymbolTypeId(pNewBaseClassType->InternalGetId()));
+}
+
+//*************************************************
+// Data APIs:
+//
+
+Object DataObject::CreateGlobal(_In_ const Object& /*dataObject*/, 
+                                _In_ ComPtr<SymbolSet>& spSymbolSet,
+                                _In_ std::wstring dataName,
+                                _In_ Object dataType,
+                                _In_ ULONG64 dataOffset,
+                                _In_ std::optional<std::wstring> qualifiedDataName)
+{
+    SymbolSet *pSymbolSet = spSymbolSet.Get();
+    BaseTypeSymbol *pDataType = UnboxType(spSymbolSet.Get(), dataType);
+
+    PCWSTR pwszName = dataName.c_str();
+    PCWSTR pwszQualifiedName = (qualifiedDataName.has_value() ? qualifiedDataName.value().c_str() : nullptr);
+
+    ComPtr<GlobalDataSymbol> spGlobalData;
+    CheckHr(MakeAndInitialize<GlobalDataSymbol>(&spGlobalData, 
+                                                pSymbolSet,
+                                                0,
+                                                dataOffset,
+                                                pDataType->InternalGetId(),
+                                                pwszName,
+                                                pwszQualifiedName));
+
+    GlobalDataObject& globalDataFactory = ApiProvider::Get().GetGlobalDataFactory();
+    return globalDataFactory.CreateInstance(spGlobalData);
+}
+
+std::experimental::generator<Object> DataObject::GetIterator(_In_ const Object& /*dataObject*/,
+                                                             _In_ ComPtr<SymbolSet>& spSymbolSet)
+{
+    //
+    // We must take **GREAT CARE** with what we touch and how we iterate.  After a co_yield, the state
+    // of things may have drastically changed.  We must refetch things and only rely upon positional
+    // counters!
+    //
+    size_t cur = 0;
+    for(;;)
+    {
+        auto&& globalSymbols = spSymbolSet->InternalGetGlobalSymbols();
+        if (cur >= globalSymbols.size())
+        {
+            break;
+        }
+
+        ULONG64 nextGlobal = globalSymbols[cur];
+        ++cur;
+
+        BaseSymbol *pNextSymbol = spSymbolSet->InternalGetSymbol(nextGlobal);
+        if (pNextSymbol->InternalGetKind() != SvcSymbolData)
+        {
+            continue;
+        }
+
+        GlobalDataSymbol *pNextGlobalData = static_cast<GlobalDataSymbol *>(pNextSymbol);
+        ComPtr<GlobalDataSymbol> spGlobalData = pNextGlobalData;
+        GlobalDataObject& globalDataFactory = ApiProvider::Get().GetGlobalDataFactory();
+        Object globalDataObject = globalDataFactory.CreateInstance(spGlobalData);
+        co_yield globalDataObject;
+    }
+}
+
+//*************************************************
+// Global Data APIs:
+//
+
+Object GlobalDataObject::GetType(_In_ const Object& /*globalDataObject*/, 
+                                 _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol)
+{
+    return BoxRelatedType(spGlobalDataSymbol.Get(), spGlobalDataSymbol->InternalGetSymbolTypeId());
+}
+
+void GlobalDataObject::SetType(_In_ const Object& /*globalDataObject*/, 
+                               _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol,
+                               _In_ Object globalDataType)
+{
+    BaseTypeSymbol *pNewDataType = UnboxType(spGlobalDataSymbol->InternalGetSymbolSet(),
+                                             globalDataType);
+
+    CheckHr(spGlobalDataSymbol->InternalSetSymbolTypeId(pNewDataType->InternalGetId()));
+}
+
+std::optional<ULONG64> GlobalDataObject::GetOffset(_In_ const Object& /*globalDataObject*/, 
+                                                   _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol)
+{
+    std::optional<ULONG64> result;
+    
+    if (!spGlobalDataSymbol->InternalIsConstantValue())
+    {
+        result = spGlobalDataSymbol->InternalGetActualSymbolOffset();
+    }
+    return result;
+}
+
+void GlobalDataObject::SetOffset(_In_ const Object& /*globalDataObject*/,
+                                 _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol,
+                                 _In_ ULONG64 globalDataOffset)
+{
+    if (spGlobalDataSymbol->InternalIsConstantValue())
+    {
+        throw std::runtime_error("cannot set offset of global data which is constnat value");
+    }
+
+    CheckHr(spGlobalDataSymbol->InternalSetSymbolOffset(globalDataOffset));
+}
+
+std::wstring GlobalDataObject::ToString(_In_ const Object& /*globalDataObject*/,
+                                        _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol,
+                                        _In_ const Metadata& /*metadata*/)
+{
+    wchar_t buf[512];
+
+    std::wstring const& dataName = spGlobalDataSymbol->InternalGetQualifiedName();
+
+    ULONG64 dataTypeId = spGlobalDataSymbol->InternalGetSymbolTypeId();
+
+    if (spGlobalDataSymbol->InternalIsConstantValue())
+    {
+        BaseSymbol *pDataTypeSymbol = spGlobalDataSymbol->InternalGetSymbolSet()->InternalGetSymbol(dataTypeId);
+        std::wstring const& dataTypeName = pDataTypeSymbol->InternalGetQualifiedName();
+        std::wstring value = ValueToString(spGlobalDataSymbol->InternalGetSymbolValue());
+
+        swprintf_s(buf, ARRAYSIZE(buf), L"Global Data: %s (type = '%s', value = %s )",
+                   dataName.empty() ? L"<Unknown>" : dataName.c_str(),
+                   dataTypeName.empty() ? L"<Unknown>" : dataTypeName.c_str(),
+                   value.c_str());
+    }
+    else
+    {
+        BaseSymbol *pDataTypeSymbol = spGlobalDataSymbol->InternalGetSymbolSet()->InternalGetSymbol(dataTypeId);
+        std::wstring const& dataTypeName = pDataTypeSymbol->InternalGetQualifiedName();
+
+        swprintf_s(buf, ARRAYSIZE(buf), L"Global Data: %s ( type = '%s', module offset = %d )",
+                   dataName.empty() ? L"<Unknown>" : dataName.c_str(),
+                   dataTypeName.empty() ? L"<Unknown>" : dataTypeName.c_str(),
+                   (ULONG)spGlobalDataSymbol->InternalGetActualSymbolOffset());
+    }
+
+    return (std::wstring)buf;
+}
+
+void GlobalDataObject::Delete(_In_ const Object& /*globalDataObject*/,
+                              _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol)
+{
+    CheckHr(spGlobalDataSymbol->Delete());
+}
+
+//*************************************************
+// Data Model Bindings:
+//
+// The constructors for our extension points & typed model / factory objects set up all of the available properties,
+// methods, etc...  which are available in the data model and which C++ methods act as the callbacks for fetching /
+// setting properties, calling methods, etc...
+//
+// Each property or method may associate an optional metadata store which can have some key properties:
+//
+//     "Help"       - A string which provides "help text" for the property or method (e.g.: single line tool tip style)
+//     "PreferShow" - Indicates whether the property/method should be shown by default (methods are hidden by default)
+//
+
+ModuleExtension::ModuleExtension() :
+    ExtensionModel(NamedModelParent(L"Debugger.Models.Module"))
+{
+    AddReadOnlyProperty(L"SymbolBuilderSymbols", this, &ModuleExtension::GetSymbolBuilderSymbols,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_MODULE_SYMBOLBUILDERSYMBOLS }));
+}
+       
+SymbolSetObject::SymbolSetObject() :
+    TypedInstanceModel()
+{
+    AddReadOnlyProperty(L"Data", this, &SymbolSetObject::GetData,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_SYMBOLSET_DATA }));
+
+    AddReadOnlyProperty(L"Types", this, &SymbolSetObject::GetTypes,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_SYMBOLSET_TYPES }));
+}
+
+TypesObject::TypesObject() :
+    TypedInstanceModel()
+{
+    AddMethod(L"AddBasicCTypes", this, &TypesObject::AddBasicCTypes,
+               Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPES_ADDBASICCTYPES },
+                        L"PreferShow", true));
+
+    AddMethod(L"Create", this, &TypesObject::Create,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPES_CREATE },
+                       L"PreferShow", true));
+
+    AddMethod(L"CreateArray", this, &TypesObject::CreateArray,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPES_CREATEARRAY },
+                       L"PreferShow", true));
+
+    AddMethod(L"CreateEnum", this, &TypesObject::CreateEnum,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPES_CREATEENUM },
+                       L"PreferShow", true));
+
+    AddMethod(L"CreatePointer", this, &TypesObject::CreatePointer,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPES_CREATEPOINTER },
+                       L"PreferShow", true));
+
+    AddMethod(L"CreateTypedef", this, &TypesObject::CreateTypedef,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPES_CREATETYPEDEF },
+                       L"PreferShow", true));
+
+    AddGeneratorFunction(this, &TypesObject::GetIterator);
+}
+
+template<typename TSym>
+BaseSymbolObject<TSym>::BaseSymbolObject() :
+    TypedInstanceModel<ComPtr<TSym>>()
+{
+    this->AddReadOnlyProperty(L"Name", this, &BaseSymbolObject::GetName,
+                              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_SYMBOL_NAME }));
+
+    this->AddReadOnlyProperty(L"QualifiedName", this, &BaseSymbolObject::GetQualifiedName,
+                              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_SYMBOL_QUALIFIEDNAME }));
+
+    this->AddReadOnlyProperty(L"Parent", this, &BaseSymbolObject::GetParent,
+                              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_SYMBOL_PARENT }));
+}
+
+template<typename TType>
+BaseTypeObject<TType>::BaseTypeObject(_In_ PCWSTR pwszConvTag) :
+    m_pwszConvTag(pwszConvTag)
+{
+    this->AddReadOnlyProperty(L"Size", this, &BaseTypeObject::GetSize,
+                              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPE_SIZE }));
+
+    this->AddReadOnlyProperty(L"Alignment", this, &BaseTypeObject::GetAlignment,
+                              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPE_ALIGNMENT }));
+
+    this->AddStringDisplayableFunction(this, &BaseTypeObject::ToString);
+
+    this->AddMethod(L"Delete", this, &BaseTypeObject::Delete,
+                    Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPE_DELETE }));
+}
+
+BasicTypeObject::BasicTypeObject() :
+    BaseTypeObject(L"Basic Type")
+{
+}
+
+UdtTypeObject::UdtTypeObject() :
+    BaseTypeObject(L"UDT")
+{
+    AddReadOnlyProperty(L"BaseClasses", this, &UdtTypeObject::GetBaseClasses,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_UDTTYPE_BASECLASSES }));
+
+    AddReadOnlyProperty(L"Fields", this, &UdtTypeObject::GetFields,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_UDTTYPE_FIELDS }));
+}
+
+PointerTypeObject::PointerTypeObject() :
+    BaseTypeObject(L"Pointer")
+{
+    AddReadOnlyProperty(L"BaseType", this, &PointerTypeObject::GetBaseType,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_POINTERTYPE_BASETYPE }));
+}
+
+ArrayTypeObject::ArrayTypeObject() :
+    BaseTypeObject(L"Array")
+{
+    AddReadOnlyProperty(L"ArraySize", this, &ArrayTypeObject::GetArraySize,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_ARRAYTYPE_ARRAYSIZE }));
+
+    AddReadOnlyProperty(L"BaseType", this, &ArrayTypeObject::GetBaseType,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_ARRAYTYPE_BASETYPE }));
+}
+
+TypedefTypeObject::TypedefTypeObject() :
+    BaseTypeObject(L"Typedef")
+{
+    AddReadOnlyProperty(L"BaseType", this, &TypedefTypeObject::GetBaseType,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_TYPEDEFTYPE_BASETYPE }));
+}
+
+EnumTypeObject::EnumTypeObject() :
+    BaseTypeObject(L"Enum")
+{
+    AddReadOnlyProperty(L"BaseType", this, &EnumTypeObject::GetBaseType,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_ENUMTYPE_BASETYPE }));
+
+    AddReadOnlyProperty(L"Enumerants", this, &EnumTypeObject::GetEnumerants,
+                        Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_ENUMTYPE_ENUMERANTS }));
+}
+
+FieldsObject::FieldsObject() :
+    TypedInstanceModel()
+{
+    AddMethod(L"Add", this, &FieldsObject::Add,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_FIELDS_ADD },
+                       L"PreferShow", true));
+
+    AddGeneratorFunction(this, &FieldsObject::GetIterator);
+}
+
+EnumerantsObject::EnumerantsObject() :
+    TypedInstanceModel()
+{
+    AddMethod(L"Add", this, &EnumerantsObject::Add,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_ENUMERANTS_ADD },
+                       L"PreferShow", true));
+
+    AddGeneratorFunction(this, &EnumerantsObject::GetIterator);
+}
+
+FieldObject::FieldObject()
+{
+    AddStringDisplayableFunction(this, &FieldObject::ToString);
+
+    AddProperty(L"IsAutomaticLayout", this, &FieldObject::GetIsAutomaticLayout, &FieldObject::SetIsAutomaticLayout,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_FIELD_ISAUTOMATICLAYOUT }));
+
+    AddProperty(L"Type", this, &FieldObject::GetType, &FieldObject::SetType,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_FIELD_TYPE }));
+
+    AddProperty(L"Offset", this, &FieldObject::GetOffset, &FieldObject::SetOffset,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_FIELD_OFFSET }));
+
+    AddMethod(L"Delete", this, &FieldObject::Delete,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_FIELD_DELETE }));
+
+    AddMethod(L"MoveBefore", this, &FieldObject::MoveBefore,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_FIELD_MOVEBEFORE }));
+}
+
+BaseClassesObject::BaseClassesObject() :
+    TypedInstanceModel()
+{
+    AddMethod(L"Add", this, &BaseClassesObject::Add,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_BASECLASSES_ADD },
+                       L"PreferShow", true));
+
+    AddGeneratorFunction(this, &BaseClassesObject::GetIterator);
+}
+
+BaseClassObject::BaseClassObject()
+{
+    AddStringDisplayableFunction(this, &BaseClassObject::ToString);
+
+    AddProperty(L"IsAutomaticLayout", this, &BaseClassObject::GetIsAutomaticLayout, &BaseClassObject::SetIsAutomaticLayout,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_BASECLASS_ISAUTOMATICLAYOUT }));
+
+    AddProperty(L"Type", this, &BaseClassObject::GetType, &BaseClassObject::SetType,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_BASECLASS_TYPE }));
+
+    AddProperty(L"Offset", this, &BaseClassObject::GetOffset, &BaseClassObject::SetOffset,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_BASECLASS_OFFSET }));
+
+    AddMethod(L"Delete", this, &BaseClassObject::Delete,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_BASECLASS_DELETE }));
+
+    AddMethod(L"MoveBefore", this, &BaseClassObject::MoveBefore,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_BASECLASS_MOVEBEFORE }));
+}
+
+DataObject::DataObject()
+{
+    AddMethod(L"CreateGlobal", this, &DataObject::CreateGlobal,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_DATA_CREATEGLOBAL },
+                       L"PreferShow", true));
+
+    AddGeneratorFunction(this, &DataObject::GetIterator);
+}
+
+GlobalDataObject::GlobalDataObject()
+{
+    AddStringDisplayableFunction(this, &GlobalDataObject::ToString);
+
+    AddProperty(L"Type", this, &GlobalDataObject::GetType, &GlobalDataObject::SetType,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_GLOBALDATA_TYPE }));
+
+    AddProperty(L"Offset", this, &GlobalDataObject::GetOffset, &GlobalDataObject::SetOffset,
+                Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_GLOBALDATA_OFFSET }));
+
+    AddMethod(L"Delete", this, &GlobalDataObject::Delete,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_GLOBALDATA_DELETE }));
+}
+
+SymbolBuilderNamespace::SymbolBuilderNamespace() :
+    ExtensionModel(NamespacePropertyParent(L"Debugger.Models.Utility",
+                                           L"Debugger.Models.Utility.SymbolBuilder",
+                                           L"SymbolBuilder"))
+{
+    AddMethod(L"CreateSymbols", this, &SymbolBuilderNamespace::CreateSymbols,
+              Metadata(L"Help", DeferredResourceString { SYMBOLBUILDER_IDS_CREATESYMBOLS },
+                       L"PreferShow", true));
+}
+
+} // SymbolBuilder
+} // Libraries
+} // DataModel
+} // Debugger
+
+//*************************************************
+// Core Initialization:
+//
+
+using namespace Debugger::DataModel::Libraries::SymbolBuilder;
+
+void UninitializeObjectModel()
+{
+    if (g_pProvider != nullptr)
+    {
+        delete g_pProvider;
+        g_pProvider = nullptr;
+    }
+
+    if (g_pManager != nullptr)
+    {
+        g_pManager->Release();
+        g_pManager = nullptr;
+    }
+
+    if (g_pHost != nullptr)
+    {
+        g_pHost->Release();
+        g_pHost = nullptr;
+    }
+}
+
+HRESULT InitializeObjectModel(_In_ IUnknown *pHostInterface)
+{
+    HRESULT hr = S_OK;
+
+    //
+    // DbgModelClientEx.h providers throw exceptions.  Most of that is managed by the extension itself
+    // and it does all the requisite translation.  The original initialization where we hook things up is an
+    // exception to this.  We must bound any C++ exception which comes out.
+    //
+    try
+    {
+        ComPtr<IHostDataModelAccess> spAccess;
+
+        hr = pHostInterface->QueryInterface(IID_PPV_ARGS(&spAccess));
+        if (SUCCEEDED(hr))
+        {
+            hr = spAccess->GetDataModel(&g_pManager, &g_pHost);
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            g_pProvider = new ApiProvider;
+        }
+    }
+    catch(...)
+    {
+        hr = E_FAIL;
+    }
+
+    if (FAILED(hr))
+    {
+        UninitializeObjectModel();
+    }
+
+    return hr;
+}
+

--- a/TargetComposition/SymBuilder/ApiProvider.h
+++ b/TargetComposition/SymBuilder/ApiProvider.h
@@ -1,0 +1,867 @@
+//**************************************************************************
+//
+// ApiProvider.h
+//
+// Header for a provider for the data model which extends Debugger.Utility.*
+// to create new APIs to access our underlying functionality.
+//
+// The provider here is implemented with the C++17 data model client library.
+// Effectively, there are a series of classes whose constructors bind certain C++ methods
+// to the data model as property getters and setters or method callbacks.
+//
+// The global ApiProvider object houses all of these classes.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __APIPROVIDER_H__
+#define __APIPROVIDER_H__
+
+namespace Debugger
+{
+namespace DataModel
+{
+namespace Libraries
+{
+namespace SymbolBuilder
+{
+
+using namespace Debugger::DataModel::ClientEx;
+using namespace Debugger::DataModel::ProviderEx;
+using namespace Debugger::TargetComposition::Services::SymbolBuilder;
+using namespace Microsoft::WRL;
+
+//*************************************************
+// Helpers:
+//
+
+// SymbolObjectHelpers:
+//
+// Base class providing some general helpers for various boxed symbols.
+//
+class SymbolObjectHelpers
+{
+public:
+
+    // UnboxType():
+    //
+    // Takes an object which may be a type name or one of the various type objects we created and unboxes it
+    // to a BaseTypeSymbol.  Note that no reference count is returned on the resulting pointer.  It is valid
+    // solely by the fact that it is in the global symbol table of the symbol set.
+    //
+    BaseTypeSymbol *UnboxType(_In_ SymbolSet *pSymbolSet, _In_ Object typeObject, _In_ bool allowAutoCreations = true);
+
+    // BoxRelatedType():
+    //
+    // Takes one of our types as identified by a type id (related to an existing symbol; for example, the
+    // base type of a pointer) and boxes it into the data model by finding and calling the appropriate factory object.
+    //
+    Object BoxRelatedType(_In_ BaseSymbol *pSymbol, _In_ ULONG64 typeId);
+
+    // BoxType():
+    //
+    // Takes one of our types and boxes it into the data model by finding and calling the appropriate factory
+    // object.
+    //
+    Object BoxType(_In_ BaseTypeSymbol *pTypeSymbol);
+
+    // BoxSymbol():
+    //
+    // Takes one of our symbols and boxes it into the data model by finding and calling the appropriate factory
+    // object.
+    //
+    Object BoxSymbol(_In_ BaseSymbol *pSymbol);
+};
+
+// SymbolSetObject:
+//
+// Represents one of our symbol set objects boxed into the data model.
+//
+class SymbolSetObject : public TypedInstanceModel<ComPtr<SymbolSet>>
+{
+public:
+
+    SymbolSetObject();
+
+private:
+
+    // GetTypes():
+    //
+    // Property accessor which gets the types on this symbol set.
+    //
+    Object GetTypes(_In_ const Object& /*symbolSetObject*/, _In_ ComPtr<SymbolSet>& spSymbolSet);
+
+    // GetData():
+    //
+    // Property accessor which gets the data on this symbol set.
+    //
+    Object GetData(_In_ const Object& /*symbolSetObject*/, _In_ ComPtr<SymbolSet>& spSymbolSet);
+};
+
+//*************************************************
+// Base Symbols:
+//
+
+// BaseSymbolObject:
+//
+// Base class for our symbol objects which provides helpers and some basic bindings.
+//
+template<typename TSym>
+class BaseSymbolObject : public TypedInstanceModel<ComPtr<TSym>>,
+                         public SymbolObjectHelpers
+{
+public:
+
+    BaseSymbolObject();
+
+protected:
+
+    // GetName():
+    //
+    // Bound property accessor to get the name of the symbol.
+    //
+    Object GetName(_In_ const Object& symbolObject, _In_ ComPtr<TSym>& spSymbol);
+
+    // GetQualifiedName():
+    //
+    // Bound property accessor to get the qualified name of the symbol.
+    //
+    Object GetQualifiedName(_In_ const Object& symbolObject, _In_ ComPtr<TSym>& spSymbol);
+
+    // GetParent():
+    //
+    // Bound property accessor to get the parent of the symbol.
+    //
+    Object GetParent(_In_ const Object& symbolObject, _In_ ComPtr<TSym>& spSymbol);
+
+private:
+};
+
+//*************************************************
+// Types:
+//
+
+// BaseTypeObject:
+//
+// Base class for various types boxed into the data model.
+//
+template<typename TType>
+class BaseTypeObject : public BaseSymbolObject<TType>
+{
+public:
+
+    BaseTypeObject(_In_ PCWSTR pwszConvTag);
+
+protected:
+
+    // GetSize():
+    //
+    // Bound property accessor which gets the size of the type.
+    //
+    ULONG64 GetSize(_In_ const Object& typeObject, _In_ ComPtr<TType>& spTypeSymbol);
+
+    // GetAlignment():
+    //
+    // Bound property accessor which gets the alignment of the type.
+    //
+    ULONG64 GetAlignment(_In_ const Object& typeObject, _In_ ComPtr<TType>& spTypeSymbol);
+
+    // ToString():
+    //
+    // Bound function that is the string conversion for a type.
+    //
+    std::wstring ToString(_In_ const Object& typeObject,
+                          _In_ ComPtr<TType>& spTypeSymbol,
+                          _In_ const Metadata& metadata);
+
+    // Delete():
+    //
+    // Bound method which will delete a type.
+    //
+    void Delete(_In_ const Object& typeObject, _In_ ComPtr<TType>& spTypeSymbol);
+
+private:
+
+    // String conversion tag.
+    PCWSTR m_pwszConvTag;
+
+};
+
+// TypesObject:
+//
+// Represents the list of types (and type APIs) available on a symbol set.
+//
+class TypesObject : public TypedInstanceModel<ComPtr<SymbolSet>>,
+                    public SymbolObjectHelpers
+{
+public:
+
+    TypesObject();
+
+private:
+
+    // AddBasicCTypes():
+    //
+    // Bound API which will add basic C types to the symbol set with standard Windows definitions.
+    //
+    void AddBasicCTypes(_In_ const Object& typesObject, _In_ ComPtr<SymbolSet>& spSymbolSet);
+
+    // Create():
+    //
+    // Bound API which will create a new UDT and return an object representing it.
+    //
+    Object Create(_In_ const Object& typesObject, 
+                  _In_ ComPtr<SymbolSet>& spSymbolSet,
+                  _In_ std::wstring typeName,
+                  _In_ std::optional<std::wstring> qualifiedTypeName);
+
+    // CreatePointer():
+    //
+    // Bound API which will create a new pointer to something and return an object representing it.
+    //
+    Object CreatePointer(_In_ const Object& typesObject,
+                         _In_ ComPtr<SymbolSet>& spSymbolSet,
+                         _In_ Object pointedToType);
+
+    // CreateArray():
+    //
+    // Bound API which will create a new array of something and return an object representing it.
+    //
+    Object CreateArray(_In_ const Object& typesObject,
+                       _In_ ComPtr<SymbolSet>& spSymbolSet,
+                       _In_ Object arrayOfType,
+                       _In_ ULONG64 arrayDim);
+
+    // CreateTypedef():
+    //
+    // Bound API which will create a new typedef of something and return an object representing it.
+    //
+    Object CreateTypedef(_In_ const Object& typesObject,
+                         _In_ ComPtr<SymbolSet>& spSymbolSet,
+                         _In_ std::wstring typeName,
+                         _In_ Object typedefOfType,
+                         _In_ std::optional<std::wstring> qualifiedTypeName);
+
+    // CreateEnum():
+    //
+    // Bound API which will create a new enum of something and return an object representing it.
+    //
+    Object CreateEnum(_In_ const Object& typesObject,
+                      _In_ ComPtr<SymbolSet>& spSymbolSet,
+                      _In_ std::wstring typeName,
+                      _In_ std::optional<Object> enumBasicType,
+                      _In_ std::optional<std::wstring> qualifiedTypeName);
+
+    // GetIterator():
+    //
+    // Bound generator for iterating over types within a symbol set.
+    //
+    std::experimental::generator<Object> GetIterator(_In_ const Object& typesObject,
+                                                     _In_ ComPtr<SymbolSet>& spSymbolSet);
+
+};
+
+
+// UdtTypeObject:
+//
+// Represents one of our UDT symbol objects boxed into the data model.
+//
+class UdtTypeObject : public BaseTypeObject<UdtTypeSymbol>
+{
+public:
+
+    UdtTypeObject();
+
+private:
+
+    // GetBaseClasses()
+    //
+    // Property accessor which gets the base classes on this UDT.
+    //
+    Object GetBaseClasses(_In_ const Object& /*typeObject*/, _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol);
+
+    // GetFields():
+    //
+    // Property accessor which gets the fields on this UDT.
+    //
+    Object GetFields(_In_ const Object& /*typeObject*/, _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol);
+
+};
+
+// BasicTypeObject:
+//
+// Represents one of our basic (intrinsic type) symbol objects boxed into the data model.
+//
+class BasicTypeObject : public BaseTypeObject<BasicTypeSymbol>
+{
+public:
+
+    BasicTypeObject();
+
+};
+
+// PointerTypeObject:
+//
+// Represents a pointer type symbol boxed into the data model.
+//
+class PointerTypeObject : public BaseTypeObject<PointerTypeSymbol>
+{
+public:
+
+    PointerTypeObject();
+
+private:
+
+    // GetBaseType():
+    //
+    // Property accessor which gets the base type of this pointer (what it points to)
+    //
+    Object GetBaseType(_In_ const Object& /*typeObject*/, _In_ ComPtr<PointerTypeSymbol>& spPointerTypeSymbol);
+};
+
+// ArrayTypeObject:
+//
+// Represents an array type symbol boxed into the data model.
+//
+class ArrayTypeObject : public BaseTypeObject<ArrayTypeSymbol>
+{
+public:
+
+    ArrayTypeObject();
+
+private:
+
+    // GetBaseType():
+    //
+    // Property accessor which gets the base type of this array (what it is an array of)
+    //
+    Object GetBaseType(_In_ const Object& /*arrayObject*/, _In_ ComPtr<ArrayTypeSymbol>& spArrayTypeSymbol);
+
+    // GetArraySize():
+    //
+    // Bound property accessor which returns the size of the array (number of elements).
+    //
+    ULONG64 GetArraySize(_In_ const Object& arrayObject, _In_ ComPtr<ArrayTypeSymbol>& spArraySymbol);
+};
+
+// TypedefTypeObject:
+//
+// Represenhts a typedef type symbol boxed into the data model.
+//
+class TypedefTypeObject : public BaseTypeObject<TypedefTypeSymbol>
+{
+public:
+
+    TypedefTypeObject();
+
+private:
+
+    // GetBaseType():
+    //
+    // Property accessor which gets the base type of this typedef (what it is a typedef of)
+    //
+    Object GetBaseType(_In_ const Object& /*typedefObject*/, _In_ ComPtr<TypedefTypeSymbol>& spTypedefTypeSymbol);
+};
+
+// EnumTypeObject:
+//
+// Represenhts an enum type symbol boxed into the data model.
+//
+class EnumTypeObject : public BaseTypeObject<EnumTypeSymbol>
+{
+public:
+
+    EnumTypeObject();
+
+private:
+
+    // GetBaseType():
+    //
+    // Property accessor which gets the base type of this enum (the basic type of the enum)
+    //
+    Object GetBaseType(_In_ const Object& /*enumObject*/, _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol);
+
+    // GetEnumerants():
+    //
+    // Property accessor which gets the list of enumerants within this enum (the values)
+    //
+    Object GetEnumerants(_In_ const Object& /*enumObject*/, _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol);
+};
+
+// FieldsObject:
+//
+// Represents the list of fields (and APIs) available on a UDT type.
+//
+class FieldsObject : public TypedInstanceModel<ComPtr<UdtTypeSymbol>>,
+                     public SymbolObjectHelpers
+{
+public:
+
+    FieldsObject();
+
+private:
+
+    // Add():
+    //
+    // Adds a new field to the UDT.  The 'fieldType' may either be a fully qualified type name
+    // or may be a type object returned from something like SymbolSet.CreateType().  If the 'fieldOffset'
+    // is supplied, the field will be placed specifically at that offset.  If it is not, the field will be
+    // appended to the end of the UDT (+ requisite alignment padding) and will alter the UDTs size and layout.
+    // 
+    Object Add(_In_ const Object& typeObject,
+               _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol,
+               _In_ std::wstring fieldName,
+               _In_ Object fieldType,
+               _In_ std::optional<ULONG64> fieldOffset);
+
+    // GetIterator():
+    //
+    // Bound generator for iterating over fields within a type.
+    //
+    std::experimental::generator<Object> GetIterator(_In_ const Object& fieldsObject,
+                                                     _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol);
+
+};
+
+// EnumerantsObject:
+//
+// Represents the list of enumerants (and APIs) available on an enum type.  This is slightly different than
+// the more general "fields" concept because for enums, everything must be a constant valued "enumerant" (really
+// a field) that matches the underlying enum type.
+//
+class EnumerantsObject : public TypedInstanceModel<ComPtr<EnumTypeSymbol>>,
+                         public SymbolObjectHelpers
+{
+public:
+
+    EnumerantsObject();
+
+private:
+
+    // Add():
+    //
+    // Adds a new enumerant to the enum.  If the value is unspecified, it acts as a "C enum" where it will
+    // auto-increment from the previous enumerant value.
+    //
+    Object Add(_In_ const Object& enumObject,
+               _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol,
+               _In_ std::wstring enumerantName,
+               _In_ std::optional<Object> enumerantValue);
+
+    // GetIterator():
+    //
+    // Bound generator for iterating over enumerants within an enum.
+    //
+    std::experimental::generator<Object> GetIterator(_In_ const Object& enumObject,
+                                                     _In_ ComPtr<EnumTypeSymbol>& spEnumTypeSymbol);
+
+
+};
+
+// FieldObject:
+//
+// Represents one of our field objects boxed into the data model.
+//
+class FieldObject : public BaseSymbolObject<FieldSymbol>
+{
+public:
+
+    FieldObject();
+
+private:
+
+    // [Get/Set]IsAutomaticLayout():
+    //
+    // Bound property accessor which determines whether the field is automatic layout or not.
+    //
+    std::optional<bool> GetIsAutomaticLayout(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol);
+    void SetIsAutomaticLayout(_In_ const Object& fieldObject,
+                              _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                              _In_ bool isAutomaticLayout);
+
+    // [Get/Set]Type():
+    //
+    // Bound property accessor which returns the type of the field.
+    //
+    Object GetType(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol);
+    void SetType(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                 _In_ Object fieldType);
+
+    // [Get/Set]Offset():
+    //
+    // Bound property accessor which returns the offset of the field.
+    //
+    std::optional<ULONG64> GetOffset(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol);
+    void SetOffset(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                   _In_ ULONG64 fieldOffset);
+
+    // Delete():
+    //
+    // Bound method which will delete a field of a type.
+    //
+    void Delete(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol);
+
+    // MoveBefore():
+    //
+    // Bound method which moves the field to before another field.  The 'beforeObj' may either be another
+    // field or it may be the numeric index of a field.
+    //
+    void MoveBefore(_In_ const Object& fieldObject, _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                    _In_ Object beforeObj);
+
+    // ToString():
+    //
+    // Bound function that is the string conversion for a UDT field.
+    //
+    std::wstring ToString(_In_ const Object& fieldObject,
+                          _In_ ComPtr<FieldSymbol>& spFieldSymbol,
+                          _In_ const Metadata& metadata);
+
+};
+
+// BaseClassesObject:
+//
+// Represents the list of base classes (and APIs) available on a UDT type.
+//
+class BaseClassesObject : public TypedInstanceModel<ComPtr<UdtTypeSymbol>>
+{
+public:
+
+    BaseClassesObject();
+
+private:
+
+    // Add():
+    //
+    // Adds a new base class to the UDT.  The 'fieldType' may either be a fully qualified type name
+    // or may be a type object returned from something like SymbolSet.CreateType().  If the 'baseClassOffset'
+    // is supplied, the field will be placed specifically at that offset.  If it is not, the field will be
+    // appended to the end of the base class list (+ requisite alignment padding) and will alter the UDTs size 
+    // and layout.
+    // 
+    Object Add(_In_ const Object& typeObject,
+               _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol,
+               _In_ Object baseClassType,
+               _In_ std::optional<ULONG64> baseClassOffset);
+
+    // GetIterator():
+    //
+    // Bound generator for iterating over fields within a type.
+    //
+    std::experimental::generator<Object> GetIterator(_In_ const Object& baseClassesObject,
+                                                     _In_ ComPtr<UdtTypeSymbol>& spUdtTypeSymbol);
+
+};
+
+// BaseClassObject:
+//
+// Represents one of our base class objects boxed into the data model.
+//
+class BaseClassObject : public BaseSymbolObject<BaseClassSymbol>
+{
+public:
+
+    BaseClassObject();
+
+private:
+
+    // [Get/Set]IsAutomaticLayout():
+    //
+    // Bound property accessor which determines whether the base class is automatic layout or not.
+    //
+    bool GetIsAutomaticLayout(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol);
+    void SetIsAutomaticLayout(_In_ const Object& baseClassObject,
+                              _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                              _In_ bool isAutomaticLayout);
+
+    // [Get/Set]Type():
+    //
+    // Bound property accessor which returns the type of the base class.
+    //
+    Object GetType(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol);
+    void SetType(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                 _In_ Object baseClassType);
+
+    // [Get/Set]Offset():
+    //
+    // Bound property accessor which returns the offset of the base class.
+    //
+    ULONG64 GetOffset(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol);
+    void SetOffset(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                   _In_ ULONG64 baseClassOffset);
+
+    // Delete():
+    //
+    // Bound method which will delete a base class of a type.
+    //
+    void Delete(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol);
+
+    // MoveBefore():
+    //
+    // Bound method which moves the base class to before another base class.  The 'beforeObj' may either be another
+    // base class or it may be the numeric index of a base class.
+    //
+    void MoveBefore(_In_ const Object& baseClassObject, _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                    _In_ Object beforeObj);
+
+    // ToString():
+    //
+    // Bound function that is the string conversion for a UDT field.
+    //
+    std::wstring ToString(_In_ const Object& baseClassObject,
+                          _In_ ComPtr<BaseClassSymbol>& spBaseClassSymbol,
+                          _In_ const Metadata& metadata);
+
+};
+
+//*************************************************
+// Data:
+//
+
+// DataObject:
+//
+// Represents the list of data (and data APIs) available on a symbol set.
+//
+class DataObject : public TypedInstanceModel<ComPtr<SymbolSet>>,
+                   public SymbolObjectHelpers
+{
+public:
+
+    DataObject();
+
+private:
+
+    // CreateGlobal():
+    //
+    // Bound API which will create a new piece of global data and return an object representing it.
+    //
+    Object CreateGlobal(_In_ const Object& typesObject, 
+                        _In_ ComPtr<SymbolSet>& spSymbolSet,
+                        _In_ std::wstring dataName,
+                        _In_ Object dataType,
+                        _In_ ULONG64 dataOffset,
+                        _In_ std::optional<std::wstring> qualifiedDataName);
+
+    // GetIterator():
+    //
+    // Bound generator for iterating over data within a symbol set.
+    //
+    std::experimental::generator<Object> GetIterator(_In_ const Object& dataObject,
+                                                     _In_ ComPtr<SymbolSet>& spSymbolSet);
+
+};
+
+// GlobalDataObject:
+//
+// Represents a global data objects boxed into the data model.
+//
+class GlobalDataObject : public BaseSymbolObject<GlobalDataSymbol>
+{
+public:
+
+    GlobalDataObject();
+
+private:
+
+    // [Get/Set]Type():
+    //
+    // Bound property accessor which returns the type of the global data.
+    //
+    Object GetType(_In_ const Object& globalDataObject, _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol);
+    void SetType(_In_ const Object& globalDataObject, _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol,
+                 _In_ Object globalDataType);
+
+    // [Get/Set]Offset():
+    //
+    // Bound property accessor which returns the offset of the global data.
+    //
+    std::optional<ULONG64> GetOffset(_In_ const Object& globalDataObject, 
+                                     _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol);
+    void SetOffset(_In_ const Object& globalDataObject, _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol,
+                   _In_ ULONG64 globalDataOffset);
+
+    // ToString():
+    //
+    // Bound function that is the string conversion for global data.
+    //
+    std::wstring ToString(_In_ const Object& globalDataObject,
+                          _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol,
+                          _In_ const Metadata& metadata);
+
+    // Delete():
+    //
+    // Bound method which will delete global data.
+    //
+    void Delete(_In_ const Object& globalDataObject, _In_ ComPtr<GlobalDataSymbol>& spGlobalDataSymbol);
+};
+
+//*************************************************
+// Extension Points:
+//
+
+// ModuleExtension:
+//
+// An extension on the debugger's notion of a module which presents any symbol builder symbols associated
+// with the given module.
+//
+class ModuleExtension : public ExtensionModel
+{
+public:
+    
+    ModuleExtension();
+
+private:
+
+    // GetSymbolBuilderSymbols():
+    //
+    // Bound property accessor which retrieves the symbol builder symbols associated with the given module.
+    //
+    Object GetSymbolBuilderSymbols(_In_ const Object& moduleObject);
+
+};
+
+// SymbolBuilderNamespace:
+//
+// This is what provides *OUR* library's additions to <API>.SymbolBuilder
+//
+class SymbolBuilderNamespace : public ExtensionModel
+{
+public:
+
+    // SymbolBuilderNamespace()
+    //
+    // Creates the symbol builder namespace
+    //
+    SymbolBuilderNamespace();
+
+private:
+
+    // CreateSymbols():
+    //
+    // Creates a new symbol builder set for a given module.  We support several forms of CreateSymbols():
+    //
+    //     CreateSymbols(moduleObject)     // moduleObject is @$curprocess.Modules[N]
+    //     CreateSymbols(moduleBase)       // moduleBase is the base address of a module in the current process context
+    //     CreateSymbols(moduleName)       // moduleName is the name of a module in the current process context
+    //
+    Object CreateSymbols(_In_ const Object& contextObject, _In_ Object moduleArg);
+
+};
+
+//*************************************************
+// Main Provider:
+//
+
+// ApiProvider:
+//
+// The singleton provider class which adds "Debugger.Utility.SymbolBuilder.*" as
+// new APIs via the data model.
+//
+class ApiProvider
+{
+public:
+
+    ApiProvider();
+    ~ApiProvider();
+
+    //*************************************************
+    // General Factories:
+    //
+
+    SymbolSetObject& GetSymbolSetFactory() const { return *m_spSymbolSetFactory.get(); }
+    TypesObject& GetTypesFactory() const { return *m_spTypesFactory.get(); }
+    DataObject& GetDataFactory() const { return *m_spDataFactory.get(); }
+
+    //
+    // Types:
+    //
+
+    BasicTypeObject& GetBasicTypeFactory() const { return *m_spBasicTypeFactory.get(); }
+    UdtTypeObject& GetUdtTypeFactory() const { return *m_spUdtTypeFactory.get(); }
+    PointerTypeObject& GetPointerTypeFactory() const { return *m_spPointerTypeFactory.get(); }
+    ArrayTypeObject& GetArrayTypeFactory() const { return *m_spArrayTypeFactory.get(); }
+    TypedefTypeObject& GetTypedefTypeFactory() const { return *m_spTypedefTypeFactory.get(); }
+    EnumTypeObject& GetEnumTypeFactory() const { return *m_spEnumTypeFactory.get(); }
+
+    //
+    // Data:
+    //
+
+    GlobalDataObject& GetGlobalDataFactory() const { return *m_spGlobalDataFactory.get(); }
+
+    //
+    // Other Symbols:
+    //
+
+    FieldsObject& GetFieldsFactory() const { return *m_spFieldsFactory.get(); }
+    FieldObject& GetFieldFactory() const { return *m_spFieldFactory.get(); }
+    BaseClassesObject& GetBaseClassesFactory() const { return *m_spBaseClassesFactory.get(); }
+    BaseClassObject& GetBaseClassFactory() const { return *m_spBaseClassFactory.get(); }
+    EnumerantsObject& GetEnumerantsFactory() const { return *m_spEnumerantsFactory.get(); }
+
+    // Get():
+    //
+    // Gets the api provider instance.
+    //
+    static ApiProvider& Get()
+    {
+        return *s_pProvider;
+    }
+
+private:
+
+    static ApiProvider *s_pProvider;
+
+    //*************************************************
+    // General Factories:
+    //
+
+    std::unique_ptr<SymbolSetObject> m_spSymbolSetFactory;
+    std::unique_ptr<TypesObject> m_spTypesFactory;
+    std::unique_ptr<DataObject> m_spDataFactory;
+
+    //
+    // Types:
+    //
+
+    std::unique_ptr<BasicTypeObject> m_spBasicTypeFactory;
+    std::unique_ptr<UdtTypeObject> m_spUdtTypeFactory;
+    std::unique_ptr<PointerTypeObject> m_spPointerTypeFactory;
+    std::unique_ptr<ArrayTypeObject> m_spArrayTypeFactory;
+    std::unique_ptr<TypedefTypeObject> m_spTypedefTypeFactory;
+    std::unique_ptr<EnumTypeObject> m_spEnumTypeFactory;
+
+    //
+    // Data:
+    //
+
+    std::unique_ptr<GlobalDataObject> m_spGlobalDataFactory;
+    
+
+    //
+    // Other Symbols:
+    //
+
+    std::unique_ptr<FieldsObject> m_spFieldsFactory;
+    std::unique_ptr<FieldObject> m_spFieldFactory;
+    std::unique_ptr<BaseClassesObject> m_spBaseClassesFactory;
+    std::unique_ptr<BaseClassObject> m_spBaseClassFactory;
+    std::unique_ptr<EnumerantsObject> m_spEnumerantsFactory;
+
+    //*************************************************
+    // Extension Points:
+
+    std::unique_ptr<SymbolBuilderNamespace> m_spSymbolBuilderNamespaceExtension;
+    std::unique_ptr<ModuleExtension> m_spModuleExtension;
+
+};
+
+} // SymbolBuilder
+} // Libraries
+} // DataModel
+} // Debugger
+
+#endif // __APIPROVIDER_H__

--- a/TargetComposition/SymBuilder/Extension.cpp
+++ b/TargetComposition/SymBuilder/Extension.cpp
@@ -1,0 +1,153 @@
+//**************************************************************************
+//
+// Extension.cpp
+//
+// Main export functions to be a debugger extension.  These exports are the standard
+// DbgEng export functions for an extension DLL and hook up the functionality necessary
+// for us to "extend" symbols.  Note that this extension is an extension at two different
+// levels of the debugger:
+//
+// 1) The target composition (lower level)
+//
+//    Here -- the extension exposes a new kind of symbol -- one which we construct in memory
+//    based on a series of API calls.
+//
+// 2) The data model (upper level)
+//
+//     Here -- the extension exposes APIs that allow modification of the symbols provided
+//     at the target composition level.
+//
+// A **GREAT DEAL** of care must be taken to keep a clean division between these two parts.  Data
+// model extensions and things at the data model level frequently depend on target composition
+// components and services.  Things at the target composition level **CANNOT** depend on anything
+// at the data model level without **EXTREME CARE**.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+//*************************************************
+// GUID Defintions for the plug-in
+// 
+
+#define INITGUID
+#include <guiddef.h>
+#include "InternalGuids.h"
+#undef INITGUID
+
+#define KDEXT_64BIT
+#include <dbgeng.h>
+
+using namespace Microsoft::WRL;
+using namespace Debugger::TargetComposition::Services::SymbolBuilder;
+
+IDebugTargetComposition *g_pCompositionManager = nullptr;
+IDebugTargetCompositionBridge *g_pCompositionBridge = nullptr;
+
+//*************************************************
+// Hooks For Data Model:
+//
+// These are the *ONLY* things files outside the API / data model portion of
+// the extension are allowed to touch!
+//
+
+HRESULT InitializeObjectModel(_In_ IUnknown *pHostInterface);
+void UninitializeObjectModel();
+
+//*************************************************
+// Utility
+//
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymBuilder
+{
+
+HRESULT DiagnosticLog(_In_opt_ ISvcDiagnosticLogging *pDiagnosticLogging,
+                      _In_ DiagnosticLogLevel level,
+                      _In_ DiagnosticLogLevel setLevel,
+                      _In_opt_ PCWSTR pwszComponent,
+                      _In_opt_ PCWSTR pwszCategory,
+                      _In_ _Printf_format_string_ PCWSTR pwszMessage,
+                      ...)
+{
+    if (pDiagnosticLogging == nullptr || level < setLevel)
+    {
+        return S_FALSE;
+    }
+
+    HRESULT hr = E_FAIL;
+
+    va_list vl;
+    va_start(vl, pwszMessage);
+
+    wchar_t msg[1024];
+    if (vswprintf_s(msg, ARRAYSIZE(msg), pwszMessage, vl) > 0)
+    {
+        hr = pDiagnosticLogging->Log(level, msg, pwszComponent, pwszCategory);
+    }
+
+    va_end(vl);
+
+    return hr;
+}
+
+} // TextDump
+} // Services
+} // TargetComposition
+} // Debugger
+
+//**************************************************************************
+// Classic DbgEng Style Initialization:
+//
+// Here, we simply call to initialize our provider.  Everything else is keyed off API 
+// calls from the projected data model objects.
+//
+
+extern "C"
+HRESULT CALLBACK DebugExtensionInitialize(PULONG /*pVersion*/, PULONG /*pFlags*/)
+{
+    HRESULT hr = S_OK;
+
+    ComPtr<IDebugClient> spClient;
+    IfFailedReturn(DebugCreate(__uuidof(IDebugClient), (void **)&spClient));
+
+    IfFailedReturn(InitializeObjectModel(spClient.Get()));
+
+    return hr;
+}
+
+extern "C"
+HRESULT CALLBACK DebugExtensionCanUnload(void)
+{
+    //
+    // We can successfully unload if there are *NO OBJECTS* left.  When we uninitialize, we will unregister
+    // our activator and release any global references.  Note that just because the activator will no longer
+    // open *NEW FILES*, that does *NOT* mean that there isn't still a file open using this extension.
+    // We cannot successfully unload if *ANY* objects are still alive.
+    //
+    // Only if there are zero objects left do we say this is okay.
+    //
+    auto objCount = Microsoft::WRL::Module<InProc>::GetModule().GetObjectCount();
+    return (objCount == 0) ? S_OK : S_FALSE;
+}
+
+extern "C"
+void CALLBACK DebugExtensionUninitialize(void)
+{
+    UninitializeObjectModel();
+}
+
+extern "C"
+void CALLBACK DebugExtensionUnload(void)
+{
+}
+

--- a/TargetComposition/SymBuilder/HelpStrings.h
+++ b/TargetComposition/SymBuilder/HelpStrings.h
@@ -1,0 +1,145 @@
+//**************************************************************************
+//
+// HelpStrings.h
+//
+// Resource identifiers for help strings.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef _HELPSTRINGS_H_
+#define _HELPSTRINGS_H_
+
+//*************************************************
+// Extension Points:
+//
+
+#define SYMBOLBUILDER_IDS_MODULE_SYMBOLBUILDERSYMBOLS 100
+#define SYMBOLBUILDER_IDS_CREATESYMBOLS 101
+
+//*************************************************
+// Type Related Objects:
+//
+
+//
+// <SymbolSet>
+//
+
+#define SYMBOLBUILDER_IDS_SYMBOLSET_TYPES 200
+#define SYMBOLBUILDER_IDS_SYMBOLSET_DATA 201
+
+//
+// <SymbolSet>.Types:
+//
+
+#define SYMBOLBUILDER_IDS_TYPES_ADDBASICCTYPES 300
+#define SYMBOLBUILDER_IDS_TYPES_CREATE 301
+#define SYMBOLBUILDER_IDS_TYPES_CREATEARRAY 302
+#define SYMBOLBUILDER_IDS_TYPES_CREATEENUM 303
+#define SYMBOLBUILDER_IDS_TYPES_CREATEPOINTER 304
+#define SYMBOLBUILDER_IDS_TYPES_CREATETYPEDEF 305
+
+//
+// <Base Symbol>.*
+//
+
+#define SYMBOLBUILDER_IDS_SYMBOL_NAME 400
+#define SYMBOLBUILDER_IDS_SYMBOL_QUALIFIEDNAME 401
+#define SYMBOLBUILDER_IDS_SYMBOL_PARENT 402
+
+//
+// <Base Type>.*
+//
+
+#define SYMBOLBUILDER_IDS_TYPE_SIZE 500
+#define SYMBOLBUILDER_IDS_TYPE_ALIGNMENT 501
+#define SYMBOLBUILDER_IDS_TYPE_DELETE 502
+
+//
+// <UDT>.*
+//
+
+#define SYMBOLBUILDER_IDS_UDTTYPE_BASECLASSES 600
+#define SYMBOLBUILDER_IDS_UDTTYPE_FIELDS 601
+
+//
+// <Pointer>.*
+//
+
+#define SYMBOLBUILDER_IDS_POINTERTYPE_BASETYPE 700
+
+//
+// <Array>.*
+//
+
+#define SYMBOLBUILDER_IDS_ARRAYTYPE_ARRAYSIZE 800
+#define SYMBOLBUILDER_IDS_ARRAYTYPE_BASETYPE 801
+
+//
+// <Typedef>.*
+//
+
+#define SYMBOLBUILDER_IDS_TYPEDEFTYPE_BASETYPE 900
+
+//
+// <Enum>.*
+
+#define SYMBOLBUILDER_IDS_ENUMTYPE_BASETYPE 1000
+#define SYMBOLBUILDER_IDS_ENUMTYPE_ENUMERANTS 1001
+
+//
+// <Fields>.*
+//
+
+#define SYMBOLBUILDER_IDS_FIELDS_ADD 1100
+
+//
+// <Enumerants>.*
+//
+
+#define SYMBOLBUILDER_IDS_ENUMERANTS_ADD 1200
+
+//
+// <Field>.*
+//
+
+#define SYMBOLBUILDER_IDS_FIELD_ISAUTOMATICLAYOUT 1300
+#define SYMBOLBUILDER_IDS_FIELD_TYPE 1301
+#define SYMBOLBUILDER_IDS_FIELD_OFFSET 1302
+#define SYMBOLBUILDER_IDS_FIELD_DELETE 1303
+#define SYMBOLBUILDER_IDS_FIELD_MOVEBEFORE 1304
+
+//
+// <Base Classes>.*
+//
+
+#define SYMBOLBUILDER_IDS_BASECLASSES_ADD 1400
+
+//
+// <Base Class>.*
+//
+
+#define SYMBOLBUILDER_IDS_BASECLASS_ISAUTOMATICLAYOUT 1500
+#define SYMBOLBUILDER_IDS_BASECLASS_TYPE 1501
+#define SYMBOLBUILDER_IDS_BASECLASS_OFFSET 1502
+#define SYMBOLBUILDER_IDS_BASECLASS_DELETE 1503
+#define SYMBOLBUILDER_IDS_BASECLASS_MOVEBEFORE 1504
+
+//
+// <Data>.*
+//
+
+#define SYMBOLBUILDER_IDS_DATA_CREATEGLOBAL 2000
+
+//
+// <Global Data>.*
+//
+
+#define SYMBOLBUILDER_IDS_GLOBALDATA_TYPE 2100
+#define SYMBOLBUILDER_IDS_GLOBALDATA_OFFSET 2101
+#define SYMBOLBUILDER_IDS_GLOBALDATA_DELETE 2102
+
+#endif // __HELPSTRINGS_H_

--- a/TargetComposition/SymBuilder/HelpStrings.rc
+++ b/TargetComposition/SymBuilder/HelpStrings.rc
@@ -1,0 +1,58 @@
+//**************************************************************************
+//
+// HelpStrings.rc
+//
+// Resource file for help strings.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "HelpStrings.h"
+
+STRINGTABLE
+BEGIN
+    SYMBOLBUILDER_IDS_MODULE_SYMBOLBUILDERSYMBOLS   "The symbol builder symbols for the module"
+    SYMBOLBUILDER_IDS_CREATESYMBOLS                 "CreateSymbols(module) - Creates symbol builder symbols for the module in question.  'module' can be the name or base address of a module or a module object"
+    SYMBOLBUILDER_IDS_SYMBOLSET_TYPES               "The list of available types"
+    SYMBOLBUILDER_IDS_SYMBOLSET_DATA                "The list of available global data"
+    SYMBOLBUILDER_IDS_TYPES_ADDBASICCTYPES          "AddBasicCTypes() - For symbol builder symbols created without default C types, this adds the default C types to the type system"
+    SYMBOLBUILDER_IDS_TYPES_CREATE                  "Create(typeName, [qualifiedTypeName]) - Creates a new user defined type.  An explicit 'qualifiedTypeName' may be optionally provided if different than the base name"
+    SYMBOLBUILDER_IDS_TYPES_CREATEARRAY             "CreateArray(baseType, arraySize) - Creates a new array type.  'baseType' may either be a type object or a type name.  'arraySize' is the size of the array"
+    SYMBOLBUILDER_IDS_TYPES_CREATEENUM              "CreateEnum(typeName, [basicType], [qualifiedTypeName]) - Creates a new enum type.  'basicType' is the type of the enum; if unspecified, the default is 'int'.  An explicit 'qualifiedTypeName' may optionally be provided if different than the base name"
+    SYMBOLBUILDER_IDS_TYPES_CREATEPOINTER           "CreatePointer(baseType) - Creates a new pointer to the given type"
+    SYMBOLBUILDER_IDS_TYPES_CREATETYPEDEF           "CreateTypedef(typeName, baseType, [qualifiedTypeName]) - Creates a new typedef to 'baseType'.  An explicit 'qualifiedTypeName' may optionally be provided if different than the base name"
+    SYMBOLBUILDER_IDS_SYMBOL_NAME                   "The name of the symbol"
+    SYMBOLBUILDER_IDS_SYMBOL_QUALIFIEDNAME          "The qualified name of the symbol"
+    SYMBOLBUILDER_IDS_SYMBOL_PARENT                 "The parent of the symbol"
+    SYMBOLBUILDER_IDS_TYPE_SIZE                     "The size of the type as if sizeof(t) had been applied"
+    SYMBOLBUILDER_IDS_TYPE_ALIGNMENT                "The alignment of the type as if __alignof(t) had been applied"
+    SYMBOLBUILDER_IDS_TYPE_DELETE                   "Delete() - Deletes the type from the symbol builder symbols.  Any live objects of the given type are orphaned"
+    SYMBOLBUILDER_IDS_UDTTYPE_BASECLASSES           "The list of base classes of the type"
+    SYMBOLBUILDER_IDS_UDTTYPE_FIELDS                "The list of fields of the type"
+    SYMBOLBUILDER_IDS_POINTERTYPE_BASETYPE          "The type which the pointer points to"
+    SYMBOLBUILDER_IDS_ARRAYTYPE_ARRAYSIZE           "The size of the array"
+    SYMBOLBUILDER_IDS_ARRAYTYPE_BASETYPE            "The type which the array is an array of"
+    SYMBOLBUILDER_IDS_TYPEDEFTYPE_BASETYPE          "The type which this typedef refers to"
+    SYMBOLBUILDER_IDS_ENUMTYPE_BASETYPE             "The basic underlying type of the enum"
+    SYMBOLBUILDER_IDS_ENUMTYPE_ENUMERANTS           "The list of enumerants of the enum"
+    SYMBOLBUILDER_IDS_FIELDS_ADD                    "Add(name, type, [offset]) - Adds a new field of the given name and type.  'type' may be a type name or type object.  If 'offset' is supplied, the field will be placed at the given offset; otherwise, it will be placed automatically as if defined in a C structure"
+    SYMBOLBUILDER_IDS_ENUMERANTS_ADD                "Add(name, [value]) - Adds a new enumerant of the given name and value.  If 'value' is supplied, the enumerant has an explicitly assigned value; otherwise, it will be assigned automatically as if defined in a C enum"
+    SYMBOLBUILDER_IDS_FIELD_ISAUTOMATICLAYOUT       "Whether or not the field or enumerant has automatically assigned offsets and/or values"
+    SYMBOLBUILDER_IDS_FIELD_TYPE                    "The type of the field"
+    SYMBOLBUILDER_IDS_FIELD_OFFSET                  "The offset of the field"
+    SYMBOLBUILDER_IDS_FIELD_DELETE                  "Delete() - Deletes the field or enumerant from its parent type/enum"
+    SYMBOLBUILDER_IDS_FIELD_MOVEBEFORE              "MoveBefore(pos) - Moves this field/enumerant to a location in its parent type before the given field/enumerant.  Note that 'pos' may either be a field/enumerant object or it may be a zero based ordinal indicating its position within the list of fields/enumerants"
+    SYMBOLBUILDER_IDS_BASECLASSES_ADD               "Add(baseClassType, [offset]) - Adds a new base class of the given type.  If 'offset' is supplied, the base class will be placed at the given offset; otherwise, it will be placed automatically as if defined in a C++ struct/class"
+    SYMBOLBUILDER_IDS_BASECLASS_ISAUTOMATICLAYOUT   "Indicates whether the base class has an automatically assigned offset within its parent type"
+    SYMBOLBUILDER_IDS_BASECLASS_TYPE                "The type of the base class"
+    SYMBOLBUILDER_IDS_BASECLASS_OFFSET              "The offset of the base class within its parent type"
+    SYMBOLBUILDER_IDS_BASECLASS_DELETE              "Delete() - Deletes the base class from its parent type"
+    SYMBOLBUILDER_IDS_BASECLASS_MOVEBEFORE          "MoveBefore(pos) - Moves this base class to a location in its parent type before the given base class.  Note that 'pos' may either be a base class object or it may be a zero based ordinal indicating its position within the list of base classes"
+    SYMBOLBUILDER_IDS_DATA_CREATEGLOBAL             "CreateGlobal(name, type, offset, [qualifiedName]) - Adds new global data of a specified 'type' at 'offset' bytes into the module.  An explicit 'qualifiedName' may optionally be provided if different than the base name"
+    SYMBOLBUILDER_IDS_GLOBALDATA_TYPE               "The type of the global data"
+    SYMBOLBUILDER_IDS_GLOBALDATA_OFFSET             "The offset of the global data within its loaded module"
+    SYMBOLBUILDER_IDS_GLOBALDATA_DELETE             "Delete() - Deletes the global data"
+END

--- a/TargetComposition/SymBuilder/InternalGuids.h
+++ b/TargetComposition/SymBuilder/InternalGuids.h
@@ -1,0 +1,20 @@
+//**************************************************************************
+//
+// InternalGuids.h
+//
+// Internal GUID definitions for the symbol builder plug-in
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+// DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER:
+//
+// A private service GUID that identifies a management component that we place into the service container.
+//
+// {BC2D0864-A077-43fc-BDEE-2F5572316001}
+//
+DEFINE_GUID(DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER, 0xbc2d0864, 0xa077, 0x43fc, 0xbd, 0xee, 0x2f, 0x55, 0x72, 0x31, 0x60, 0x1);
+

--- a/TargetComposition/SymBuilder/ObjectModel.h
+++ b/TargetComposition/SymBuilder/ObjectModel.h
@@ -1,0 +1,25 @@
+//**************************************************************************
+//
+// ObjectModel.h
+//
+// Core header for the object model part of the extension.  This provides separation
+// between parts that are higher level and the rest of the extension.
+//
+// Only portions of the extension which need to touch the data model include this 
+// header.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __OBJECTMODEL_H__
+#define __OBJECTMODEL_H__
+
+#include <DbgModel.h>
+#include <DbgModelClientEx.h>
+
+#include "ApiProvider.h"
+
+#endif // __OBJECTMODEL_H__

--- a/TargetComposition/SymBuilder/Readme.txt
+++ b/TargetComposition/SymBuilder/Readme.txt
@@ -1,0 +1,597 @@
+//**************************************************************************
+// Debugger Target Composition API Sample Walkthrough
+//
+// Synthetic Symbol Builder
+//**************************************************************************
+
+//*************************************************
+// INTRODUCTION
+//*************************************************
+
+The debugger's target composition API (DbgServices.h) allows plug-ins to come in and either teach
+the debugger new functionality or alter behaviors of the debugger.  At present, this API is *MOSTLY*
+focused on post-mortem targets (e.g.: dumps or similar) although certain functionality can be
+useful in live targets as well.
+
+The main notion of "target composition" is that a target that is being debugged is not a monolithic
+construct.  It is, instead, a container of interdependent services, each of which can be implemented
+by different plug-ins.  These services, in aggregate, provide the functionality which you observe in
+the debugger.  As an example, when you issue a command in the debugger such as "db 1000", the
+implementation of that command will go to the service container and find the appropriate service
+to satisfy the request.  In the case of "db 1000", the debugger will ask for the virtual memory service
+as identified by a GUID (DEBUG_SERVICE_VIRTUAL_MEMORY), get the memory access interface (ISvcMemoryAccess) 
+from that service, and call a method (ReadMemory) on that interface.
+
+Plug-ins for target composition are DbgEng style extensions that can be loaded and utilized in several different 
+ways.  They can either be brought in to handle a particular post-mortem file format or they can be brought in
+dynamically when certain conditions are met (e.g.: the underlying operating system is Windows or Linux,
+the debugger is targeting a kernel mode or user mode target, a particular module is present in the module list,
+etc...).
+
+This sample is an example of a modification of the service container.  The sample plug-in inserts a symbol
+provider into the service container.  This symbol provider allows the plug-in to handle symbols for any module
+that it wishes instead of relying on PDBs or export symbols within a binary.
+
+The sample also provides an upper-edge API through the debugger data model that allows dynamic manipulation of
+types and symbol information via data model properties and methods.
+
+//*************************************************
+// BUILDING AND LOADING
+//*************************************************
+
+* Build the sample with the included Visual Studio solution
+
+* Load the extension in the debugger (e.g.: ".load SymbolBuilderComposition.dll")
+
+//*************************************************
+// SOURCES TOUR
+//*************************************************
+
+This plug-in is separated into several distinct layers:
+
+1) The core extension (boilerplate necessary to be an extension and register):
+
+    * Extension.cpp             - The core exports required to be a debugger extension DLL
+    
+    * SymBuilder.h              - The main extension header
+
+    * InternalGuids.h           - GUID definitions
+
+Outside of the general boilerplate code required for any DLL to be a debugger extension, this plug-in is
+separated into two very distinct layers:
+
+2) The lower edge target composition layer (using DbgServices.h)
+
+The primary portion of the extension is an implementation of a symbol provider and a set of symbols using the
+target composition API.  It is *IMPERATIVE* that this part of the extension *NOT* touch anything at the data model
+layer.  Many pieces of data model implementation are based upon target composition!  Files are:
+
+    * SymbolServices.[h/cpp]    - The core service implementation of a symbol provider.  This is what handles
+                                  requests to find symbols for any given module.
+
+    * SymbolSet.[h/cpp]         - The base implementation of a symbol set.  Symbol sets are an abstraction of
+                                  symbols for a particular module.  Each symbol set is implemented as a stacked
+                                  set of interfaces.  All symbol sets must implement ISvcSymbolSet.  The more features
+                                  the symbol set supports, the more ISvcSymbolSet* interfaces the symbol set
+                                  implements.
+
+    * SymbolBase.[h/cpp]        - A base class for all symbols that we support (e.g.: types, fields, global data,
+                                  etc...)
+
+    * SymbolTypes.[h/cpp]       - Classes necessary to implement types (e.g.: structs, unions, basic types, etc...)
+
+    * SymbolData.[h/cpp]        - Classes necessary to implement data symbols (e.g.: fields, global variables, etc...)
+
+    * SymManager.[h/cpp]        - A management service which is placed into the service container to keep track 
+                                  of all of the synthetic symbols which have been created.  While this could have
+                                  been placed within the symbol provider itself, it can often be easier for other
+                                  services to access if it is within its own unique service (particularly if
+                                  multiple symbol providers are aggregated together).
+
+3) The upper edge data model layer (using DbgModel.h and DbgModelClientEx.h)
+
+    ApiProvider.[h/cpp]         - The API exposed to the data model allowing for manipulation of symbols, types,
+                                  and other functionality exposed by the lower edge target composition layer.
+
+    HelpStrings.h               - The header for all resource strings for the data model APIs (e.g.: help text)
+
+    HelpStrings.rc              - All of the resource strings for the data model APIs (e.g.: help text)
+
+    ObjectModel.h               - The main header for the data model portions of the extension.  This is specifically
+                                  separated from SymBuilder.h so that lower edge target composition portions of the 
+                                  extension *CANNOT TOUCH* upper edge data model portions.
+
+//*************************************************
+// DATA MODEL API
+//*************************************************
+
+Everything provided by this debugger extension is accessed through a data model API.  There are two main
+extensibility points of note:
+
+The main point of access is a *CreateSymbols* API present on a namespace "SymbolBuilder" added to "Debugger.Utility":
+
+    Debugger.Utility.SymbolBuilder
+    ------------------------------
+        CreateSymbols    [CreateSymbols(module) - Creates symbol builder symbols for the module in question.  'module' can be the name or base address of a module or a module object]
+
+The CreateSymbols API will return an object representing the set of symbols which were just created.  Note that once 
+symbol builder symbols have been created for a particular module, there will be a "SymbolBuilderSymbols" property
+on the module object.  The value of "SymbolBuilderSymbols" is the same as the return value from the "CreateSymbols"
+call.
+
+    0:000> dx @$curprocess.Modules["ntdll.dll"]
+    @$curprocess.Modules["ntdll.dll"]                 : ntdll.dll
+        BaseAddress      : 0x7ffd29db0000
+        Name             : ntdll.dll
+        Size             : 0x1f5000
+        Contents        
+        SymbolBuilderSymbols
+
+There are two properties on the symbol set object:
+
+    Symbol Set Object
+    -----------------
+        Data             [The list of available global data]
+        Types            [The list of available types]
+
+The "Data" and "Types" properties, in addition to being lists, also have APIs to create new types or data:
+
+    Types Object
+    ------------
+        AddBasicCTypes   [AddBasicCTypes() - For symbol builder symbols created without default C types, this adds the default C types to the type system]
+        Create           [Create(typeName, [qualifiedTypeName]) - Creates a new user defined type.  An explicit 'qualifiedTypeName' may be optionally provided if different than the base name]
+        CreateArray      [CreateArray(baseType, arraySize) - Creates a new array type.  'baseType' may either be a type object or a type name.  'arraySize' is the size of the array]
+        CreateEnum       [CreateEnum(typeName, [basicType], [qualifiedTypeName]) - Creates a new enum type.  'basicType' is the type of the enum; if unspecified, the default is 'int'.  An explicit 'qualifiedTypeName' may optionally be provided if different than the base name]
+        CreatePointer    [CreatePointer(baseType) - Creates a new pointer to the given type]
+        CreateTypedef    [CreateTypedef(typeName, baseType, [qualifiedTypeName]) - Creates a new typedef to 'baseType'.  An explicit 'qualifiedTypeName' may optionally be provided if different than the base name]
+
+    Data Object
+    -----------
+        CreateGlobal     [CreateGlobal(name, type, offset, [qualifiedName]) - Adds new global data of a specified 'type' at 'offset' bytes into the module.  An explicit 'qualifiedName' may optionally be provided if different than the base name]
+
+UDTs (structs and classes) may be created through the "Create" call on the "Types" object:
+
+    UDT Objects
+    -----------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Size              [The size of the type as if sizeof(t) had been applied]
+        Alignment         [The alignment of the type as if __alignof(t) had been applied]
+        BaseClasses       [The list of base classes of the type]
+        Fields            [The list of fields of the type]
+
+        Delete            [Delete() - Deletes the type from the symbol builder symbols.  Any live objects of the given type are orphaned]
+
+As with "Types" and "Data", the "Fields" and "BaseClasses" properties of a UDT object have methods available to create
+fields and base classes in addition to providing lists:
+
+    Fields Object
+    -------------
+        Add               [Add(name, type, [offset]) - Adds a new field of the given name and type.  'type' may be a type name or type object.  If 'offset' is supplied, the field will be placed at the given offset; otherwise, it will be placed automatically as if defined in a C structure]
+
+    Base Classes Object
+    -------------------
+        Add               [Add(baseClassType, [offset]) - Adds a new base class of the given type.  If 'offset' is supplied, the base class will be placed at the given offset; otherwise, it will be placed automatically as if defined in a C++ struct/class]
+
+Each added field has its own set of properties:
+
+    Field Objects
+    -------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Parent            [The parent of the symbol]
+        IsAutomaticLayout [Whether or not the field or enumerant has automatically assigned offsets and/or values]
+        Type              [The type of the field]
+        Offset            [The offset of the field]
+
+        Delete            [Delete() - Deletes the field or enumerant from its parent type/enum]
+        MoveBefore        [MoveBefore(pos) - Moves this field/enumerant to a location in its parent type before the given field/enumerant.  Note that 'pos' may either be a field/enumerant object or it may be a zero based ordinal indicating its position within the list of fields/enumerants]
+
+    Base Class Objects
+    ------------------
+        Parent            [The parent of the symbol]
+        IsAutomaticLayout [Indicates whether the base class has an automatically assigned offset within its parent type]
+        Type              [The type of the base class]
+        Offset            [The offset of the base class within its parent type]
+
+        Delete            [Delete() - Deletes the base class from its parent type]
+        MoveBefore        [MoveBefore(pos) - Moves this base class to a location in its parent type before the given base class.  Note that 'pos' may either be a base class object or it may be a zero based ordinal indicating its position within the list of base classes]
+
+Enum types are similar to classes:
+
+    Enum Type Objects
+    -----------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Size              [The size of the type as if sizeof(t) had been applied]
+        Alignment         [The alignment of the type as if __alignof(t) had been applied]
+        BaseType          [The basic underlying type of the enum]
+        Enumerants        [The list of enumerants of the enum]
+
+        Delete            [Delete() - Deletes the type from the symbol builder symbols.  Any live objects of the given type are orphaned]
+
+The values (enumerants) within an enum are given by the "Enumerants" property.  Similar to various other lists
+in this API, there are also some methods available to create new enumerants:
+
+    Enumerants Object
+    -----------------
+        Add              [Add(name, [value]) - Adds a new enumerant of the given name and value.  If 'value' is supplied, the enumerant has an explicitly assigned value; otherwise, it will be assigned automatically as if defined in a C enum]
+
+Each enumerant has properties similar to a field:
+
+    Enumerant Objects
+    -----------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Parent            [The parent of the symbol]
+        IsAutomaticLayout [Whether or not the field or enumerant has automatically assigned offsets and/or values]
+
+        Delete            [Delete() - Deletes the field or enumerant from its parent type/enum]
+        MoveBefore        [MoveBefore(pos) - Moves this field/enumerant to a location in its parent type before the given field/enumerant.  Note that 'pos' may either be a field/enumerant object or it may be a zero based ordinal indicating its position within the list of fields/enumerants]
+
+Other types have a few similar properties:
+
+    Array Type Objects
+    ------------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Size              [The size of the type as if sizeof(t) had been applied]
+        Alignment         [The alignment of the type as if __alignof(t) had been applied]
+        ArraySize         [The size of the array]
+        BaseType          [The type which the array is an array of]
+
+        Delete            [Delete() - Deletes the type from the symbol builder symbols.  Any live objects of the given type are orphaned]
+
+    Pointer Type Objects
+    --------------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Size              [The size of the type as if sizeof(t) had been applied]
+        Alignment         [The alignment of the type as if __alignof(t) had been applied]
+        BaseType          [The type which the pointer points to]
+
+        Delete            [Delete() - Deletes the type from the symbol builder symbols.  Any live objects of the given type are orphaned]
+
+    Typedef Type Objects
+    --------------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Size              [The size of the type as if sizeof(t) had been applied]
+        Alignment         [The alignment of the type as if __alignof(t) had been applied]
+        BaseType          [The type which this typedef refers to]
+
+        Delete           [Delete() - Deletes the type from the symbol builder symbols.  Any live objects of the given type are orphaned]
+
+Global data which is created with the "CreateGlobal" API has a set of available properies as well:
+
+    Global Data Objects
+    -------------------
+        Name              [The name of the symbol]
+        QualifiedName     [The qualified name of the symbol]
+        Type              [The type of the global data]
+        Offset            [The offset of the global data within its loaded module]
+
+        Delete            [Delete() - Deletes the global data]
+
+//*************************************************
+// STARTING OUT: A QUICK WALKTHROUGH
+//*************************************************
+
+When the debugger wants to find symbols for some module, it will go into the target composition service container
+and ask the symbol provider if it can find symbols via a call to the "LocateSymbolsForImage" method.  This is the
+main entry point for a plug-in which wants to handle some symbol format.  In this plug-in, you'll find that
+code in "SymbolServices.[h/cpp]"
+
+Typically, a symbol provider is registered as an *AGGREGATE* (so there can be multiple providers in one container).
+Each symbol provider in turn gets LocateSymbolsForImage called.  If it wants to handle symbols, it creates
+a symbol set which implements ISvcSymbolSet (at minimum) and returns success.  If it does not want to handle
+symbols, it returns E_UNHANDLED_REQUEST_TYPE and the request is passed to the next symbol provider in line.  The
+"symbol set" implementation for this plug-in can be found in "SymbolSet.[h/cpp]"
+
+The symbol set in this plug-in manages several things:
+
+    - A list of all symbols indexed by a unique ID.  Every reference from one symbol to another is done through 
+      this unique ID and not a direct pointer.   This is the "m_symbols" list in the SymbolSet class.
+
+    - A list of global symbols by unique ID.  This is a subset of the overall list containing symbols which are
+      considered to be in the global scope of the symbol set.  This is the "m_globalSymbols" list in the 
+      SymbolSet class.
+
+    - An index of global names to unique IDs.  For all named global symbols, this is a mapping from qualified
+      name to unique ID.  Symbols lookup by name is done through this index.  This is the "m_symbolNameMap"
+      list in the SymbolSEt class.
+
+    - A mapping of address ranges to symbols by unique ID.  All symbols (currently data) which have an address within
+      the module are in this mapping.  This is the "m_symbolRanges" map within the SymbolSet class.  This mapping
+      is a sorted list of non-overlapping address ranges and the IDs of symbols within those address ranges.
+      Lookups of symbols by offset are done using this map.
+
+There are several relationships between symbols managed through a link by unique ID:
+
+    - m_parentId: The unique ID of the parent symbol.  A field's parent is its containing type.  A base class's
+                  parent is its containing type.
+
+    - m_children: The list of child symbols by unique ID.  Fields are children of a type.  Base classes are
+                  children of a type.  
+
+                  This is managed through:
+
+                    AddChild:         Adds a symbol to the child list
+                    RemoveChild:      Removes a symbol from the child list
+                    GetChildPosition: Gets the position of a child in the list 
+                    MoveChildBefore:  Moves the position of a given child within the list of children
+
+    - m_dependentNotifySymbols: A list of symbols that must be notified if something about this symbol changes.
+                                For a field, "class X { MyType fld; }", the symbol for "fld" has "X" in this
+                                list.  This is not, however, solely a parent/child relationship.  The symbol
+                                for "MyType" has "fld" in this list.  If some new field happens to be dynamically
+                                added to "MyType", it will notify every symbol in its list.  This will cause
+                                "fld" to be notified of the change...  which will, in turn, cause "X" to be
+                                notified of the change...  which will, in turn, allow "X" to recompute its type
+                                layout to deal with the reality of the new type system.
+
+                                This is managed through:
+
+                                    AddDependentNotify:    Adds a new symbol to the notification list
+                                    RemoveDependentNotify: Removes a symbol from the notification list
+                                    NotifyDependentChange: Called for every symbol in the list when something changes
+
+The actual lookup of a symbol from its unique ID is done by an internal accessor "InternalGetSymbol" within the
+symbol set.  As it is possible to delete symbols, it is entirely possible that the resolution of some symbol
+by its unique ID may fail.  This may result in "zombie" symbols -- symbols which still exist but cannot be used
+because something they refer to has been deleted.  Such symbols will cause failures of debugger commands but
+should not cause undefined or crashing behaviors.
+
+The general hierarchy of symbols (lower edge) presently in the plug-in:
+**************************************************************************
+
+BaseSymbol (the base class of any symbol)
+    (SymbolBase.[h/cpp]
+    ^
+    |
+    |----- BaseTypeSymbol (the base class of any type)
+    |           (SymbolTypes.[h/cpp]
+    |           ^
+    |           |
+    |           |----- BasicTypeSymbol   (the implementation of intrinsic types like "int")
+    |           |
+    |           |----- UdtTypeSymbol     (the implementation of any user defined type)
+    |           |
+    |           |----- PointerTypeSymbol (the implementation of any pointer type)
+    |           |
+    |           |----- ArrayTypeSymbol   (the implementation of any array type)
+    |           |
+    |           |----- TypedefTypeSymbol (the implementation of any typedef type)
+    |           |
+    |           |----- EnumTypeSymbol    (the implementation of any enum type)
+    |
+    |
+    |----- BaseDataSymbol (the base class of any "data")
+                (SymbolData.[h/cpp]
+                ^
+                |
+                |----- UdtPositionalSymbol (the base class for things positioned within a UDT)
+                |               (SymbolTypes.[h/cpp]
+                |               ^
+                |               |
+                |               |----- FieldSymbol     (the implementation of a field within a UDT or an enumerant)
+                |               |
+                |               |----- BaseClassSymbol (the implementation of a base class within a UDT)
+                |
+                |
+                |----- GlobalDataSymbol (the implementation of a global data symbol / global variable)
+
+This hierarchy is *SOMEWHAT* mirrored on the API side (upper edge) within ApiProvider.[h/cpp]:
+**************************************************************************
+
+TypedInstanceModel<ComPtr<TSym>> (the factory base for any symbol from DbgModelClientEx.h)
+    ^
+    |      SymbolObjectHelpers   (helper classes for symbols)
+    |             ^
+    |             |
+    |----- BaseSymbolObject<TSym> (the base class of the data model projection of any symbol)
+    |             ^
+    |             |         (TSym = TType)
+    |             |----- BaseTypeObject<TType> (the base calss of the data model projection of any type)
+    |             |              ^
+    |             |              |         (TType = UdtTypeSymbol)
+    |             |              |----- UdtTypeObject     (the projection for UDT types)
+    |             |              |
+    |             |              |         (TType = BasicTypeSymbol)
+    |             |              |----- BasicTypeObject   (the projection for pointer types)
+    |             |              |
+    |             |              |         (TType = ArrayTypeSymbol)
+    |             |              |----- PointerTypeObject (the projection for array types)
+    |             |              |
+    |             |              |         (TType = TypedefTypeSymbol)
+    |             |              |----- TypedefTypeObject (the projection for typedef types)
+    |             |              |
+    |             |              |         (TType = EnumTypeSymbol)
+    |             |              |----- EnumTypeObject    (the projection for enum types)
+    |             |
+    |             |
+    |             |         (TSym = FieldSymbol)
+    |             |----- FieldObject      (the projection for a field within a UDT)
+    |             |
+    |             |         (TSym = BaseClassSymbol)
+    |             |----- BaseClassObject  (the projection for a base class of a UDT)
+    |             |
+    |             |         (TSym = GlobalDataSymbol)
+    |             |----- GlobalDataObject (the projection for global data within a symbol set)
+    | 
+    |
+    |   SymbolObjectHelpers       (helper class for symbols)
+    |     ^         
+    |     |        (TSym = UdtTypeSymbol)   
+    |---------- FieldsObject      (the projection for the list of fields within a UDT)
+    |     |   
+    |     |        (TSym = EnumTypeSymbol)
+    |---------- EnumerantsObject  (the projection for the list of enumerants in an enum)
+    |     |
+    |     |        (TSym = UdtTypeSymbol)
+    |---------- BaseClassesObject (the projection for the list of base classes within a UDT)
+    |     |
+    |     |         (TSym = SymbolSet)
+    |---------- DataObject        (the projection for the list of data in a symbol set)
+    |     |
+    |     |         (TSym = SymbolSet)
+    |---------- TypesObject       (the projection for the list of types in a symbol set)
+
+//*************************************************
+// STARTING OUT: AN EXAMPLE
+//*************************************************
+
+Once the extension is loaded, symbols can be created with the "SymbolBuilderSymbols.CreateSymbols" API.  Take the
+following example of windbg debugging notepad:
+
+//
+// Note that when I start the debugger, I have regular PDB symbols for ntdll:
+//
+0:000> lmmntdll
+Browse full module list
+start             end                 module name
+00007ffd`29db0000 00007ffd`29fa5000   ntdll      (private pdb symbols)  C:\ProgramData\Dbg\sym\ntdll.pdb\094B224BC5297445CF29F9C9BB588DC91\ntdll.pdb
+
+//
+// Now, I load the debugger extension and ask it to create Symbol Builder symbols for ntdll.  It is important
+// to note that these are not actually picked up until the debugger tries to load symbols for the given module.
+// Since ntdll already had a PDB loaded, this requires an explicit .reload:
+//
+0:000> .load d:\xtn\SymbolBuilderComposition.dll
+0:000> dx @$sym = Debugger.Utility.SymbolBuilder.CreateSymbols("ntdll.dll")
+@$sym = Debugger.Utility.SymbolBuilder.CreateSymbols("ntdll.dll")                
+    Data            
+    Types           
+0:000> .reload
+Reloading current modules
+...............
+0:000> lmmntdll
+Browse full module list
+start             end                 module name
+00007ffd`29db0000 00007ffd`29fa5000   ntdll      (service symbols: Symbol Builder Symbols)    
+
+//
+// With symbol builder symbols loaded, I can go and create a new type.  For instance, I'll create a type named
+// "foo" with two int fields, "x" and "y":
+//
+0:000> dx @$foo = @$sym.Types.Create("foo")
+@$foo = @$sym.Types.Create("foo")                 : UDT: foo ( size = 0, align = 1 )
+    Name             : foo
+    QualifiedName    : foo
+    Size             : 0x0
+    Alignment        : 0x1
+    BaseClasses     
+    Fields          
+0:000> dx @$foo.Fields.Add("x", "int")
+@$foo.Fields.Add("x", "int")                 : Field: x ( type = 'int', offset = 0 )
+    Name             : x
+    QualifiedName    : x
+    Parent           : UDT: foo ( size = 4, align = 4 )
+    IsAutomaticLayout : true
+    Type             : Basic Type: int ( size = 4, align = 4 )
+    Offset           : 0x0
+0:000> dx @$foo.Fields.Add("y", "int")
+@$foo.Fields.Add("y", "int")                 : Field: y ( type = 'int', offset = 4 )
+    Name             : y
+    QualifiedName    : y
+    Parent           : UDT: foo ( size = 8, align = 4 )
+    IsAutomaticLayout : true
+    Type             : Basic Type: int ( size = 4, align = 4 )
+    Offset           : 0x4
+
+//
+// Note that the resulting type can be used in any regular command in the debugger:
+//
+0:000> dt nt!foo
+ntdll!foo
+   +0x000 x                : Int4B
+   +0x004 y                : Int4B
+0:000> dx ((nt!foo *)@rip)
+((nt!foo *)@rip)                 : 0x7ffd29e806b0 [Type: foo *]
+    [+0x000] x                : 1208019916 [Type: int]
+    [+0x004] y                : -1019689853 [Type: int]
+
+//
+// I can even create global data with the type in question:
+//
+0:000> dx @$sym.Data.CreateGlobal("test", "foo", 0x100)
+@$sym.Data.CreateGlobal("test", "foo", 0x100)                 : Global Data: test ( type = 'foo', module offset = 256 )
+    Name             : test
+    QualifiedName    : test
+    Type             : UDT: foo ( size = 8, align = 4 )
+    Offset           : 0x100
+0:000> dx nt!test
+nt!test                 [Type: foo]
+    [+0x000] x                : 336462347 [Type: int]
+    [+0x004] y                : 1153024 [Type: int]
+0:000> ln ntdll+100
+Browse module
+Set bu breakpoint
+
+(00007ffd`29db0100)   ntdll!test   
+Exact matches:
+    ntdll!test = foo
+0:000> ln ntdll+104
+Browse module
+Set bu breakpoint
+
+(00007ffd`29db0100)   ntdll!test+0x4   
+0:000> ln ntdll+109
+Browse module
+Set bu breakpoint
+
+//
+// I can manipulate the type system dynamically and changes will immediately show up in the debugger.  Here,
+// I go and add a new field to the type "foo" and examine the changes:
+//
+0:000> dx @$foo.Fields.Add("z", "double")
+@$foo.Fields.Add("z", "double")                 : Field: z ( type = 'double', offset = 8 )
+    Name             : z
+    QualifiedName    : z
+    Parent           : UDT: foo ( size = 16, align = 8 )
+    IsAutomaticLayout : true
+    Type             : Basic Type: double ( size = 8, align = 8 )
+    Offset           : 0x8
+0:000> dt nt!foo
+ntdll!foo
+   +0x000 x                : Int4B
+   +0x004 y                : Int4B
+   +0x008 z                : Float
+0:000> ln ntdll+109
+Browse module
+Set bu breakpoint
+
+(00007ffd`29db0100)   ntdll!test+0x9   
+
+********** READ THIS **********
+
+A word of caution: the symbol builder will *CURRENTLY* allow the creation of constructs which are logically
+impossible (e.g.: having class X have a base class of Y...  and class Y having a base class of X...  or similar
+cyclic situations with fields).  The creation of such may lead the debugger into a bad state (including things like
+stack overflows).
+
+//*************************************************
+// FUTURE ENHANCEMENTS
+//*************************************************
+
+We expect to grow this sample over time to explore more of the symbol API surface and make it more generally
+useful.  Some of the future planned enhancements to this sample include:
+
+1) Improved validation of the type system created (e.g.: no cyclic base classes or fields)
+
+2) Hooking up the synthetic types JavaScript extension and its "C header parser" up to this extension.
+
+3) The ability to "import" data from other symbol sources (or stack on top of them) so that the sample is not
+   an "either-or" choice of using the symbol builder or using the generally available (whether public or private) 
+   symbols for a given module.  This would allow the symbol builder to be used to simply "extend" the symbols already
+   available for a module rather than replacing them.
+
+4) Support for functions, arguments, and scopes so that there are APIs to add function symbols with a prototype,
+   arguments, variables, and lifetime information.
+
+5) Support for using the data model disassembler to walk through a function tracing the position of function arguments
+   from a prototype and calling convention (e.g.: parameters in rcx, rdx, r8, and r9 on x64) so that you can get 
+   consistent examination of parameters to public APIs on public symbols.
+
+6) Support for serializing and deserializing the symbol builder information for a given module.
+

--- a/TargetComposition/SymBuilder/SymBuilder.h
+++ b/TargetComposition/SymBuilder/SymBuilder.h
@@ -1,0 +1,124 @@
+//**************************************************************************
+//
+// SymBuilder.h
+//
+// Core header for the symbol builder plug-in sample.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMBUILDER_H__
+#define __SYMBUILDER_H__
+
+//*************************************************
+// General:
+//
+
+#ifndef IfFailedReturn
+#define IfFailedReturn(EXPR) do { hr = (EXPR); if (FAILED(hr)) { return hr; }} while(FALSE, FALSE)
+#endif // IfFailedReturn
+
+#include <wrl.h>
+#include <wrl/client.h>
+#include <wrl/implements.h>
+#include <wrl/module.h>
+
+#include <utility>
+#include <memory>
+#include <string>
+#include <vector>
+#include <stack>
+#include <map>
+#include <unordered_map>
+#include <algorithm>
+#include <functional>
+#include <experimental/generator>
+
+#include <DbgServices.h>
+#include <DbgServicesBridgeClient.h>
+
+#include <DbgHelp.h>
+
+template<typename FN>
+HRESULT ConvertException(const FN& fn)
+{
+    HRESULT hr;
+    try
+    {
+        hr = fn();
+    }
+    catch(const std::bad_alloc&)
+    {
+        hr = E_OUTOFMEMORY;
+    }
+    catch(...)
+    {
+        hr = E_FAIL;
+    }
+
+    return hr;
+}
+
+struct BSTRDeleter
+{
+    void operator()(_In_z_ wchar_t *pwsz)
+    {
+        SysFreeString(reinterpret_cast<BSTR>(pwsz));
+    }
+};
+
+typedef std::unique_ptr<wchar_t, BSTRDeleter> bstr_ptr;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace TextDump
+{
+
+// DiagnosticLog():
+//
+// Sends a diagnostic log message given a diagnostic logging service.  If no diagnostic logging service
+// is provided, S_FALSE is returned.
+//
+// NOTE: Anything logged through this mechanism will go to the WinDbg Preview logs window assuming that the logging
+//       level is set appropriately.  Most of our services will default to logging anything of "info" category
+//       or higher.  "verbose info" is not normally logged.  This can be changed with the .targetloglevel command
+//       or a configuration file.
+//
+HRESULT DiagnosticLog(_In_opt_ ISvcDiagnosticLogging *pDiagnosticLogging,
+                      _In_ DiagnosticLogLevel level,
+                      _In_ DiagnosticLogLevel setLevel,
+                      _In_opt_ PCWSTR pwszComponent,
+                      _In_opt_ PCWSTR pwszCategory,
+                      _In_ _Printf_format_string_ PCWSTR pwszMessage,
+                      ...);
+
+} // TextDump
+} // Services
+} // TargetComposition
+} // Debugger
+
+#include "InternalGuids.h"
+#include "HelpStrings.h"
+#include "SymbolBase.h"
+#include "SymbolData.h"
+#include "SymbolTypes.h"
+#include "SymbolSet.h"
+#include "SymManager.h"
+#include "SymbolServices.h"
+
+#ifdef max
+#undef max
+#endif // max
+
+#ifdef min
+#undef min
+#endif // min
+
+#endif // __SYMBUILDER_H__

--- a/TargetComposition/SymBuilder/SymBuilder.rc
+++ b/TargetComposition/SymBuilder/SymBuilder.rc
@@ -1,0 +1,25 @@
+//**************************************************************************
+//
+// SymBuilder.rc
+//
+// Main resource file for the Symbol Builder Target Composition Extension
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include <windows.h>
+#include <ntverp.h>
+
+#define VER_FILETYPE                VFT_DLL
+#define VER_FILESUBTYPE             VFT_UNKNOWN
+#define VER_FILEDESCRIPTION_STR     "Symbol Builder Target Composition Debugger Extension"
+#define VER_INTERNALNAME_STR        "Symbol Builder Target Composition Debugger Extension"
+#define VER_ORIGINALFILENAME_STR    "SymbolBuilderComposition.dll"
+
+#include <common.ver>
+
+#include "HelpStrings.rc"
+

--- a/TargetComposition/SymBuilder/SymBuilder.sln
+++ b/TargetComposition/SymBuilder/SymBuilder.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32901.215
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SymBuilder", "SymBuilder.vcxproj", "{CB1E69EF-608A-4AF9-8303-A97150A9281E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Debug|x64.ActiveCfg = Debug|x64
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Debug|x64.Build.0 = Debug|x64
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Debug|x86.ActiveCfg = Debug|Win32
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Debug|x86.Build.0 = Debug|Win32
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Release|x64.ActiveCfg = Release|x64
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Release|x64.Build.0 = Release|x64
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Release|x86.ActiveCfg = Release|Win32
+		{CB1E69EF-608A-4AF9-8303-A97150A9281E}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7F97F5CD-8FFB-4CE6-8F27-25B683E45A4A}
+	EndGlobalSection
+EndGlobal

--- a/TargetComposition/SymBuilder/SymBuilder.vcxproj
+++ b/TargetComposition/SymBuilder/SymBuilder.vcxproj
@@ -218,15 +218,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets" Condition="Exists('packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" />
-    <Import Project="packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
     <Import Project="packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets" Condition="Exists('packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" />
+    <Import Project="packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
   </Target>
 </Project>

--- a/TargetComposition/SymBuilder/SymBuilder.vcxproj
+++ b/TargetComposition/SymBuilder/SymBuilder.vcxproj
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ApiProvider.cpp" />
+    <ClCompile Include="Extension.cpp" />
+    <ClCompile Include="SymbolBase.cpp" />
+    <ClCompile Include="SymbolData.cpp" />
+    <ClCompile Include="SymbolServices.cpp" />
+    <ClCompile Include="SymbolSet.cpp" />
+    <ClCompile Include="SymbolTypes.cpp" />
+    <ClCompile Include="SymManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ApiProvider.h" />
+    <ClInclude Include="HelpStrings.h" />
+    <ClInclude Include="InternalGuids.h" />
+    <ClInclude Include="ObjectModel.h" />
+    <ClInclude Include="SymbolBase.h" />
+    <ClInclude Include="SymbolData.h" />
+    <ClInclude Include="SymbolServices.h" />
+    <ClInclude Include="SymbolSet.h" />
+    <ClInclude Include="SymbolTypes.h" />
+    <ClInclude Include="SymBuilder.h" />
+    <ClInclude Include="SymManager.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="amd64\dbgcore.dll" />
+    <None Include="amd64\dbgeng.dll" />
+    <None Include="amd64\dbghelp.dll" />
+    <None Include="amd64\dbgmodel.dll" />
+    <None Include="arm64\dbgcore.dll" />
+    <None Include="arm64\dbgeng.dll" />
+    <None Include="arm64\dbghelp.dll" />
+    <None Include="arm64\dbgmodel.dll" />
+    <None Include="packages.config" />
+    <None Include="woa\dbgcore.dll" />
+    <None Include="woa\dbgeng.dll" />
+    <None Include="woa\dbghelp.dll" />
+    <None Include="woa\dbgmodel.dll" />
+    <None Include="x86\dbgcore.dll" />
+    <None Include="x86\dbgeng.dll" />
+    <None Include="x86\dbghelp.dll" />
+    <None Include="x86\dbgmodel.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="SymBuilder.rc" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{cb1e69ef-608a-4af9-8303-a97150a9281e}</ProjectGuid>
+    <RootNamespace>SymBuilder</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <TargetName>SymbolBuilderComposition</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <TargetName>SymbolBuilderComposition</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <TargetName>SymbolBuilderComposition</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <TargetName>SymbolBuilderComposition</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;SYMBUILDER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/await</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>dbgeng.lib;runtimeobject.lib;DbgTargetCompositionGuids.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>SymbolBuilderComposition.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;SYMBUILDER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/await</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>dbgeng.lib;runtimeobject.lib;DbgTargetCompositionGuids.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>SymbolBuilderComposition.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;SYMBUILDER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/await</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>dbgeng.lib;runtimeobject.lib;DbgTargetCompositionGuids.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>SymbolBuilderComposition.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;SYMBUILDER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/await</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalDependencies>dbgeng.lib;runtimeobject.lib;DbgTargetCompositionGuids.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>SymbolBuilderComposition.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets" Condition="Exists('packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" />
+    <Import Project="packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
+    <Import Project="packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets" Condition="Exists('packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.DataModel.CppLib.1.0.1\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets'))" />
+  </Target>
+</Project>

--- a/TargetComposition/SymBuilder/SymBuilder.vcxproj.filters
+++ b/TargetComposition/SymBuilder/SymBuilder.vcxproj.filters
@@ -1,0 +1,146 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="x86">
+      <UniqueIdentifier>{d33ecf74-f353-4067-8906-5bd388c3a475}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="woa">
+      <UniqueIdentifier>{8c5b8740-4dc4-49bc-8d1b-90bd1de57aad}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="arm64">
+      <UniqueIdentifier>{99cf6baf-372a-4a7c-b717-6e791843283a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="amd64">
+      <UniqueIdentifier>{52586b47-9960-48d9-a656-88cc97c57cfb}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ApiProvider.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Extension.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SymbolBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SymbolData.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SymbolServices.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SymbolSet.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SymbolTypes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SymManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ApiProvider.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="HelpStrings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="InternalGuids.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ObjectModel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymbolBase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymbolData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymbolServices.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymbolSet.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymbolTypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymBuilder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SymManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="x86\dbgmodel.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="x86\dbghelp.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="x86\dbgeng.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="x86\dbgcore.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="woa\dbgmodel.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="woa\dbghelp.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="woa\dbgeng.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="woa\dbgcore.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="arm64\dbgmodel.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="arm64\dbghelp.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="arm64\dbgeng.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="arm64\dbgcore.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="amd64\dbgmodel.dll">
+      <Filter>amd64</Filter>
+    </None>
+    <None Include="amd64\dbghelp.dll">
+      <Filter>amd64</Filter>
+    </None>
+    <None Include="amd64\dbgeng.dll">
+      <Filter>amd64</Filter>
+    </None>
+    <None Include="amd64\dbgcore.dll">
+      <Filter>amd64</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="SymBuilder.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/TargetComposition/SymBuilder/SymManager.cpp
+++ b/TargetComposition/SymBuilder/SymManager.cpp
@@ -1,0 +1,177 @@
+//**************************************************************************
+//
+// SymManager.cpp
+//
+// A management object which keeps track of the symbol sets that have been
+// created and which modules they are assigned to.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+using namespace Microsoft::WRL;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+IDebugServiceManager* SymbolBuilderProcess::GetServiceManager() const
+{
+    return m_pOwningManager->GetServiceManager();
+}
+
+ISvcMachineArchitecture *SymbolBuilderProcess::GetArchInfo() const
+{
+    return m_pOwningManager->GetArchInfo();
+}
+
+HRESULT SymbolBuilderProcess::CreateSymbolsForModule(_In_ ISvcModule *pModule,
+                                                     _In_ ULONG64 moduleKey,
+                                                     _COM_Outptr_ SymbolSet **ppSymbols)
+{
+    HRESULT hr = S_OK;
+    *ppSymbols = nullptr;
+
+    //
+    // We do not allow creating symbols if they already exist.  The caller must have verified depending on
+    // what they want to do here!
+    //
+    auto it = m_symbols.find(moduleKey);
+    if (it != m_symbols.end())
+    {
+        return E_INVALIDARG;
+    }
+
+    ComPtr<SymbolSet> spSymbolSet;
+    IfFailedReturn(MakeAndInitialize<SymbolSet>(&spSymbolSet, pModule, this));
+
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        m_symbols.insert( { moduleKey, spSymbolSet } );
+        return S_OK;
+    };
+    IfFailedReturn(ConvertException(fn));
+
+    *ppSymbols = spSymbolSet.Detach();
+    return hr;
+}
+
+HRESULT SymbolBuilderManager::TrackProcessForKey(_In_ ULONG64 processKey,
+                                                 _COM_Outptr_ SymbolBuilderProcess **ppProcess)
+{
+    HRESULT hr = S_OK;
+    *ppProcess = nullptr;
+
+    ComPtr<SymbolBuilderProcess> spProcess;
+
+    auto it = m_trackedProcesses.find(processKey);
+    if (it == m_trackedProcesses.end())
+    {
+        IfFailedReturn(MakeAndInitialize<SymbolBuilderProcess>(&spProcess, processKey, this));
+
+        //
+        // We cannot let an exception escape the COM boundary.
+        //
+        auto fn = [&]()
+        {
+            m_trackedProcesses.insert( { processKey, spProcess } );
+            return S_OK;
+        };
+        IfFailedReturn(ConvertException(fn));
+    }
+    else
+    {
+        spProcess = it->second;
+    }
+
+    *ppProcess = spProcess.Detach();
+    return hr;
+}
+
+HRESULT SymbolBuilderManager::TrackProcessForModule(_In_ ISvcModule *pModule, 
+                                                    _COM_Outptr_ SymbolBuilderProcess **ppProcess)
+{
+    HRESULT hr = S_OK;
+    *ppProcess = nullptr;
+
+    ULONG64 processKey;
+    IfFailedReturn(pModule->GetContainingProcessKey(&processKey));
+
+    ComPtr<SymbolBuilderProcess> spProcess;
+    IfFailedReturn(TrackProcessForKey(processKey, &spProcess));
+
+    *ppProcess = spProcess.Detach();
+    return hr;
+}
+
+HRESULT SymbolBuilderManager::TrackProcess(_In_ ISvcProcess *pProcess, 
+                                           _COM_Outptr_ SymbolBuilderProcess **ppProcess)
+{
+    HRESULT hr = S_OK;
+    *ppProcess = nullptr;
+
+    ULONG64 processKey;
+    IfFailedReturn(pProcess->GetKey(&processKey));
+
+    ComPtr<SymbolBuilderProcess> spProcess;
+    IfFailedReturn(TrackProcessForKey(processKey, &spProcess));
+
+    *ppProcess = spProcess.Detach();
+    return hr;
+}
+
+HRESULT SymbolBuilderManager::PidToProcess(_In_ ULONG64 pid,
+                                           _COM_Outptr_ ISvcProcess **ppProcess)
+{
+    HRESULT hr = S_OK;
+    *ppProcess = nullptr;
+
+    if (m_spProcEnum == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    //
+    // The process enumeration service provides a quick "key" -> "object" method.  It does not provide
+    // a quick "id" -> "object" method.  They may or may not be the same thing depending on who implements
+    // the process enumeration service.
+    //
+    // We need to take the long route.
+    //
+    ComPtr<ISvcProcessEnumerator> spProcEnum;
+    IfFailedReturn(m_spProcEnum->EnumerateProcesses(&spProcEnum));
+
+    for(;;)
+    {
+        ComPtr<ISvcProcess> spProcess;
+        IfFailedReturn(spProcEnum->GetNext(&spProcess));
+
+        ULONG64 curPid;
+        IfFailedReturn(spProcess->GetId(&curPid));
+        if (curPid == pid)
+        {
+            *ppProcess = spProcess.Detach();
+            return S_OK;
+        }
+    }
+
+    return E_BOUNDS;
+}
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger
+

--- a/TargetComposition/SymBuilder/SymManager.h
+++ b/TargetComposition/SymBuilder/SymManager.h
@@ -1,0 +1,457 @@
+//**************************************************************************
+//
+// SymManager.h
+//
+// A management object which keeps track of the symbol sets that have been
+// created and which modules they are assigned to.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMMANAGER_H__
+#define __SYMMANAGER_H__
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+class SymbolBuilderManager;
+
+// SymbolBuilderProcess:
+//
+// Tracks what modules we have defined symbols for within a given process context.
+//
+class SymbolBuilderProcess :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        IUnknown
+        >
+{
+public:
+
+    // TryGetSymbolsForModule():
+    //
+    // Checks whether we have symbols for the given module by its unique "key".  If so, true is returned
+    // and a pointer to the symbol set is passed back; otherwise, false is returned.
+    //
+    // This method does not create a new symbol set.
+    //
+    bool TryGetSymbolsForModule(_In_ ULONG64 moduleKey,
+                                _COM_Outptr_ SymbolSet **ppSymbols)
+    {
+        if (ppSymbols != nullptr)
+        {
+            *ppSymbols = nullptr;
+        }
+        auto it = m_symbols.find(moduleKey);
+        if (it == m_symbols.end())
+        {
+            return false;
+        }
+
+        if (ppSymbols != nullptr)
+        {
+            Microsoft::WRL::ComPtr<SymbolSet> spSymbols = it->second;
+            *ppSymbols = spSymbols.Detach();
+        }
+        return true;
+    }
+
+    // CreateSymbolsForModule():
+    //
+    // Creates a new symbol set for a given module by its unique "key".  This method will fail if symbols already
+    // exist for the module.  The caller has responsibility to check first.
+    //
+    HRESULT CreateSymbolsForModule(_In_ ISvcModule *pModule,
+                                   _In_ ULONG64 moduleKey,
+                                   _COM_Outptr_ SymbolSet **ppSymbols);
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    // RuntimeClassInitialize():
+    //
+    // Initializes a new SymbolBuilderProcess.
+    //
+    HRESULT RuntimeClassInitialize(_In_ ULONG64 processKey, _In_ SymbolBuilderManager *pOwningManager)
+    {
+        m_processKey = processKey;
+        m_pOwningManager = pOwningManager;
+        return S_OK;
+    }
+
+    // GetSymbolBuilderManager():
+    //
+    // Gets the symbol builder manager that this process was created from.
+    //
+    SymbolBuilderManager *GetSymbolBuilderManager() const
+    {
+        return m_pOwningManager;
+    }
+
+    // GetServiceManager():
+    //
+    // Gets the service manager that this process was created from.
+    //
+    IDebugServiceManager *GetServiceManager() const;
+
+    // GetArchInfo():
+    //
+    // Gets information about the architecture we are targeting.
+    //
+    ISvcMachineArchitecture *GetArchInfo() const;
+
+private:
+
+    // The "key" used to identify the process we represent.
+    ULONG64 m_processKey;
+
+    // A map tracking the "symbol sets" we have created for modules in this process.  This a map
+    // of module "keys" to symbol sets within the context of this process.
+    std::unordered_map<ULONG64, Microsoft::WRL::ComPtr<SymbolSet>> m_symbols;
+
+    // Weak pointer back to our owning manager.
+    SymbolBuilderManager *m_pOwningManager;
+};
+
+struct DECLSPEC_UUID("AF4E77D9-1100-4c40-BAB0-67450027FCA5") ISvcSymbolBuilderManager;
+
+// ISvcSymbolBuilderManager:
+//
+// This is an **INTERNAL ONLY** interface that we place on our management service.  When a request comes
+// in to load symbols, we go into the service container, locate the management service, query for this interface,
+// and use it to find whether we have symbols (or add them).
+//
+// Because this is an **INTERNAL ONLY** interface, we can use **INTERNAL** types like SymbolBuilderProcess within
+// its definition.
+//
+#undef INTERFACE
+#define INTERFACE ISvcSymbolBuilderManager
+DECLARE_INTERFACE_(ISvcSymbolBuilderManager, IUnknown)
+{
+    // PidToProcess():
+    //
+    // Converts a process id to the process object for it.
+    //
+    STDMETHOD(PidToProcess)(_In_ ULONG64 pid,
+                            _COM_Outptr_ ISvcProcess **ppProcess) PURE;
+
+    // ModuleBaseToModule():
+    //
+    // Converts a module base to the module object for it.
+    //
+    STDMETHOD(ModuleBaseToModule)(_In_opt_ ISvcProcess *pProcess,
+                                  _In_ ULONG64 moduleBase,
+                                  _COM_Outptr_ ISvcModule **ppModule) PURE;
+
+    // TrackProcessForModule():
+    //
+    // For a given module, find its associated process, and create tracking structures associated with
+    // that process.
+    //
+    STDMETHOD(TrackProcessForModule)(_In_ ISvcModule *pModule, 
+                                     _COM_Outptr_ SymbolBuilderProcess **ppProcess) PURE;
+
+    // TrackProcessForKey():
+    //
+    // Create tracking structures associated with a process by its unique key.
+    //
+    STDMETHOD(TrackProcessForKey)(_In_ ULONG64 processKey,
+                                  _COM_Outptr_ SymbolBuilderProcess **ppProcess) PURE;
+
+    // TrackProcess():
+    //
+    // Create tracking structures associated with a process by its interface.
+    //
+    STDMETHOD(TrackProcess)(_In_ ISvcProcess *pProcess,
+                            _COM_Outptr_ SymbolBuilderProcess **ppProcess) PURE;
+
+};
+
+// SymbolBuilderManager:
+//
+// A management object that we place in the service container in order to track information about what
+// processes and modules we have symbol sets for.
+//
+// We have a dependency on the process and module enumeration services in order to find what processes things 
+// refer to and find modules.  In addition, we will listen to certain events to notify us of modules which come 
+// and go in order to delete symbols which are no longer relevant.
+//
+class SymbolBuilderManager :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        IDebugServiceLayer,
+        ISvcSymbolBuilderManager
+        >
+{
+public:
+
+    SymbolBuilderManager() : m_pOwningManager(nullptr)
+    {
+    }
+
+    //*************************************************
+    // IDebugServiceLayer:
+    //
+
+    // RegisterServices():
+    //
+    // Registers all services contained in this component with the services manager.
+    //
+    IFACEMETHOD(RegisterServices)(_In_ IDebugServiceManager *pServiceManager)
+    {
+        HRESULT hr = S_OK;
+        IfFailedReturn(pServiceManager->RegisterService(DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER, this));
+        return hr;
+    }
+
+    // GetServiceDependencies():
+    //
+    // Returns the set of services which this service layer / component depends on.  Having sizeHardDependencies or
+    // sizeSoftDependencies set to 0 will pass back the number of dependencies and do nothing else.
+    //
+    IFACEMETHOD(GetServiceDependencies)(_In_ ServiceNotificationKind /*notificationKind*/,
+                                        _In_ IDebugServiceManager * /*pServiceManager*/,
+                                        _In_ REFGUID /*serviceGuid*/,
+                                        _In_ ULONG64 sizeHardDependencies,
+                                        _Out_writes_(sizeHardDependencies) GUID *pHardDependencies,
+                                        _Out_ ULONG64 *pNumHardDependencies,
+                                        _In_ ULONG64 sizeSoftDependencies,
+                                        _Out_writes_(sizeSoftDependencies) GUID * /*pSoftDependencies*/,
+                                        _Out_ ULONG64 *pNumSoftDependencies)
+    {
+        HRESULT hr = S_OK;
+        if (sizeHardDependencies == 0 && sizeSoftDependencies == 0)
+        {
+            *pNumHardDependencies = 3;
+            *pNumSoftDependencies = 0;
+            return S_OK;
+        }
+
+        if (sizeHardDependencies < 3)
+        {
+            return E_INVALIDARG;
+        }
+
+        pHardDependencies[0] = DEBUG_SERVICE_PROCESS_ENUMERATOR;
+        pHardDependencies[1] = DEBUG_SERVICE_MODULE_ENUMERATOR;
+        pHardDependencies[2] = DEBUG_SERVICE_ARCHINFO;
+
+        *pNumHardDependencies = 3;
+        *pNumSoftDependencies = 0;
+        return hr;
+    }
+
+    // InitializeServices():
+    //
+    // Performs initialization of the services in a service layer / component.  Services which aggregate, 
+    // encapsulate, or stack on top of other services must pass down the initialization notification in an 
+    // appropriate manner (with notificationKind set to LayeredNotification).
+    //
+    IFACEMETHOD(InitializeServices)(_In_ ServiceNotificationKind /*notificationKind*/,
+                                    _In_ IDebugServiceManager *pServiceManager,
+                                    _In_ REFIID /*serviceGuid*/)
+    {
+        HRESULT hr = S_OK;
+        m_pOwningManager = pServiceManager;
+
+        //
+        // We have a hard dependency on the process & module enumerators and arch info.  This means:
+        //
+        //     1) If we are inserted into the service container *PRIOR* to its spin up (e.g.: as part
+        //        of a file activation), it is guaranteed to be in the service container and initialized
+        //        by this point (initialization follows the ordering of a DAG of dependencies).
+        //
+        //     2) If we are inserted into the service container dynamically, there **IS NO GUARANTEE** that
+        //        the process enumeration service is there despite the dependency.  As we load in a dynamic
+        //        fashion, we must be prepared to deal with this!  Hence, we do *NOT* fail initialization
+        //        and all our calls check m_spProcEnum.
+        //
+        (void)pServiceManager->QueryService(DEBUG_SERVICE_PROCESS_ENUMERATOR, IID_PPV_ARGS(&m_spProcEnum));
+        (void)pServiceManager->QueryService(DEBUG_SERVICE_MODULE_ENUMERATOR, IID_PPV_ARGS(&m_spModEnum));
+        (void)pServiceManager->QueryService(DEBUG_SERVICE_ARCHINFO, IID_PPV_ARGS(&m_spArchInfo));
+
+        //
+        // We want to listen to modules that disappear so that we can "unload" our cached copy of the symbols.
+        //
+        IfFailedReturn(pServiceManager->RegisterEventNotification(DEBUG_SVCEVENT_MODULEDISAPPEARANCE, this));
+
+        return hr;
+    }
+
+    // NotifyServiceChange():
+    //
+    // Called when there is a change in the component registered as a service in the
+    // target composition stack.
+    //
+    IFACEMETHOD(NotifyServiceChange)(_In_ ServiceNotificationKind /*notificationKind*/,
+                                     _In_ IDebugServiceManager * /*pServiceManager*/,
+                                     _In_ REFIID serviceGuid,
+                                     _In_opt_ IDebugServiceLayer * /*pPriorService*/,
+                                     _In_opt_ IDebugServiceLayer *pNewService)
+    {
+        HRESULT hr = S_OK;
+        if (serviceGuid == DEBUG_SERVICE_PROCESS_ENUMERATOR)
+        {
+            //
+            // If the process enumerator service changed, alter our cached copy of it so that we are calling
+            // the correct service!
+            //
+            m_spProcEnum = nullptr;
+            if (pNewService != nullptr)
+            {
+                //
+                // *EVERY* process enumeration service is *REQUIRED* to support ISvcProcessEnumeration!
+                //
+                IfFailedReturn(pNewService->QueryInterface(IID_PPV_ARGS(&m_spProcEnum)));
+            }
+        }
+        else if (serviceGuid == DEBUG_SERVICE_MODULE_ENUMERATOR)
+        {
+            //
+            // If the module enumerator service changed, alter our cached copy of it so that we are calling
+            // the correct service!
+            //
+            m_spModEnum = nullptr;
+            if (pNewService != nullptr)
+            {
+                //
+                // *EVERY* module enumeration service is *REQUIRED* to support ISvcModuleEnumeration!
+                //
+                IfFailedReturn(pNewService->QueryInterface(IID_PPV_ARGS(&m_spModEnum)));
+            }
+        }
+        else if (serviceGuid == DEBUG_SERVICE_ARCHINFO)
+        {
+            //
+            // If the arch info service changed, alter our cached copy of it so that we are calling
+            // the correct service.
+            //
+            m_spArchInfo = nullptr;
+            if (pNewService != nullptr)
+            {
+                //
+                // *EVERY* arch info service is *REQUIRED* to support ISvcMachineArchitecture
+                //
+                IfFailedReturn(pNewService->QueryInterface(IID_PPV_ARGS(&m_spArchInfo)));
+            }
+        }
+
+        return hr;
+    }
+
+    // NotifyEvent():
+    //
+    // Called to notify this component that an event of interest occurred.
+    //
+    IFACEMETHOD(NotifyEvent)(_In_ IDebugServiceManager * /*pServiceManager*/,
+                             _In_ REFIID /*eventGuid*/,
+                             _In_opt_ IUnknown * /*pEventArgument*/)
+    {
+        return S_OK;
+    }
+
+
+    //*************************************************
+    // ISvcSymbolBuilderManager:
+    //
+
+    // PidToProcess():
+    //
+    // Converts a process id to the process object for it.
+    //
+    IFACEMETHOD(PidToProcess)(_In_ ULONG64 pid,
+                              _COM_Outptr_ ISvcProcess **ppProcess);
+
+    // ModuleBaseToModule():
+    //
+    // Converts a module base to the module object for it.
+    //
+    IFACEMETHOD(ModuleBaseToModule)(_In_opt_ ISvcProcess *pProcess,
+                                    _In_ ULONG64 moduleBase,
+                                    _COM_Outptr_ ISvcModule **ppModule)
+    {
+        *ppModule = nullptr;
+        if (m_spModEnum == nullptr)
+        {
+            return E_FAIL;
+        }
+
+        return m_spModEnum->FindModuleAtAddress(pProcess, moduleBase, ppModule);
+    }
+
+    // TrackProcessForModule():
+    //
+    // For a given module, find its associated process, and create tracking structures associated with
+    // that process.
+    //
+    IFACEMETHOD(TrackProcessForModule)(_In_ ISvcModule *pModule, 
+                                       _COM_Outptr_ SymbolBuilderProcess **ppProcess);
+
+    // TrackProcessForKey():
+    //
+    // Create tracking structures associated with a process by its unique key.
+    //
+    IFACEMETHOD(TrackProcessForKey)(_In_ ULONG64 processKey,
+                                    _COM_Outptr_ SymbolBuilderProcess **ppProcess);
+
+    // TrackProcess():
+    //
+    // Create tracking structures associated with a process by its interface.
+    //
+    IFACEMETHOD(TrackProcess)(_In_ ISvcProcess *pProcess,
+                              _COM_Outptr_ SymbolBuilderProcess **ppProcess);
+
+    // GetServiceManager():
+    //
+    // Gets the service manager that this process was created from.
+    //
+    IDebugServiceManager *GetServiceManager() const
+    {
+        return m_pOwningManager;
+    }
+
+    // GetArchInfo():
+    //
+    // Gets information about the machine architecture that we are targeting.
+    //
+    ISvcMachineArchitecture *GetArchInfo() const
+    {
+        return m_spArchInfo.Get();
+    }
+
+private:
+
+    // A listing of our tracked processes.
+    std::unordered_map<ULONG64, Microsoft::WRL::ComPtr<SymbolBuilderProcess>> m_trackedProcesses;
+
+    // Our container's process enumeration service.
+    Microsoft::WRL::ComPtr<ISvcProcessEnumeration> m_spProcEnum;
+
+    // Our container's module enumeration service.
+    Microsoft::WRL::ComPtr<ISvcModuleEnumeration> m_spModEnum;
+
+    // Our container's arch info service.
+    Microsoft::WRL::ComPtr<ISvcMachineArchitecture> m_spArchInfo;
+
+    // The service manager which contains and owns our lifetime.
+    IDebugServiceManager *m_pOwningManager;
+
+};
+
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Services
+
+#endif __SYMMANAGER_H__

--- a/TargetComposition/SymBuilder/SymbolBase.cpp
+++ b/TargetComposition/SymBuilder/SymbolBase.cpp
@@ -1,0 +1,265 @@
+//**************************************************************************
+//
+// SymbolBase.cpp
+//
+// The implementation of base symbols within a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+using namespace Microsoft::WRL;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+//*************************************************
+// Base Symbols:
+//
+
+HRESULT BaseSymbol::InitializeNewSymbol()
+{
+    return m_pSymbolSet->AddNewSymbol(this, &m_id);
+}
+
+HRESULT BaseSymbol::RemoveChild(_In_ ULONG64 uniqueId)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        HRESULT hr = S_OK;
+
+        bool found = false;
+        for (auto it = m_children.begin(); it != m_children.end(); ++it)
+        {
+            if (*it == uniqueId)
+            {
+                m_children.erase(it);
+                found = true;
+                break;
+            }
+        }
+
+        if (found)
+        {
+            return NotifyDependentChange();
+        }
+
+        return hr;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT BaseSymbol::MoveChildBefore(_In_ ULONG64 childId, 
+                                    _In_ ULONG64 pos,
+                                    _In_ SvcSymbolKind relativeTo)
+{
+    auto fn = [&]()
+    {
+        if (pos > std::numeric_limits<size_t>::max())
+        {
+            return E_INVALIDARG;
+        }
+
+        //
+        // Find where the child is currently at in the list of children and then find its new position
+        // depending on whether it is absolute or relative.
+        //
+        size_t idx = 0;
+        while (idx < m_children.size() && m_children[idx] != childId)
+        {
+            ++idx;
+        }
+
+        if (idx >= m_children.size())
+        {
+            return E_INVALIDARG;
+        }
+
+        //
+        // If the positioning is absolute, pos is the new position; otherwise, we must count how many symbols 
+        // of type 'relativeTo' have occurred to find the appropriate index.
+        //
+        size_t newIdx;
+        if (relativeTo == SvcSymbol)
+        {
+            newIdx = static_cast<size_t>(pos);
+        }
+        else
+        {
+            newIdx = 0;
+            ULONG64 count = 0;
+            while (newIdx < m_children.size())
+            {
+                BaseSymbol *pChild = InternalGetSymbolSet()->InternalGetSymbol(m_children[newIdx]);
+                if (pChild != nullptr && pChild->InternalGetKind() == relativeTo)
+                {
+                    if (count == pos)
+                    {
+                        break;
+                    }
+
+                    ++count;
+                }
+
+                ++newIdx;
+            }
+        }
+
+        if (newIdx > idx) { --newIdx; }
+        m_children.erase(m_children.begin() + idx);
+        m_children.insert(m_children.begin() + newIdx, childId);
+
+        // 
+        // Changing the position of a field may actually change the size of the type due to alignment and packing.
+        // This means anyone dependent on this symbol must recompute their layouts.  We need to pass this notification
+        // onward.
+        //
+        // We must also send an advisory notification upwards that everyone should flush caches.  Do not consider this
+        // a failure to create the symbol if something goes wrong.  At worst, an explicit .reload will be
+        // required in the debugger.
+        //
+        HRESULT hr = NotifyDependentChange();
+        (void)InternalGetSymbolSet()->InvalidateExternalCaches();
+        return hr;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT BaseSymbol::EnumerateChildren(_In_ SvcSymbolKind kind,
+                                      _In_opt_z_ PCWSTR pwszName,
+                                      _In_opt_ SvcSymbolSearchInfo * /*pSearchInfo*/,
+                                      _COM_Outptr_ ISvcSymbolSetEnumerator **ppChildEnum)
+{
+    HRESULT hr = S_OK;
+    *ppChildEnum = nullptr;
+
+    ComPtr<ChildEnumerator> spEnum;
+    IfFailedReturn(MakeAndInitialize<ChildEnumerator>(&spEnum, this, kind, pwszName));
+
+    *ppChildEnum = spEnum.Detach();
+    return hr;
+}
+
+HRESULT BaseSymbol::NotifyDependentChange()
+{
+    HRESULT hr = S_OK;
+    for (auto&& kvp : m_dependentNotifySymbols)
+    {
+        ULONG64 uniqueId = kvp.first;
+        BaseSymbol *pNotifySymbol = InternalGetSymbolSet()->InternalGetSymbol(uniqueId);
+        if (pNotifySymbol != nullptr)
+        {
+            hr = pNotifySymbol->NotifyDependentChange();
+            if (FAILED(hr))
+            {
+                return hr;
+            }
+        }
+    }
+
+    return hr;
+}
+
+HRESULT BaseSymbol::Delete()
+{
+    HRESULT hr = S_OK;
+    for (auto&& child : m_children)
+    {
+        HRESULT hrChild = S_OK;
+
+        BaseSymbol *pSymbol = InternalGetSymbolSet()->InternalGetSymbol(child);
+        if (pSymbol != nullptr)
+        {
+            hrChild = (pSymbol->Delete());
+        }
+
+        if (FAILED(hrChild) && SUCCEEDED(hr))
+        {
+            hr = hrChild;
+        }
+    }
+    m_children.clear();
+
+    BaseSymbol *pParentSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_parentId);
+    if (pParentSymbol != nullptr)
+    {
+        HRESULT hrParent = pParentSymbol->RemoveChild(InternalGetId());
+        if (FAILED(hrParent) && SUCCEEDED(hr))
+        {
+            hr = hrParent;
+        }
+    }
+
+    HRESULT hrDelete = InternalGetSymbolSet()->DeleteExistingSymbol(InternalGetId());
+    if (FAILED(hrDelete) && SUCCEEDED(hr))
+    {
+        hr = hrDelete;
+    }
+
+    return hr;
+}
+
+HRESULT ChildEnumerator::GetNext(_COM_Outptr_ ISvcSymbol **ppSymbol)
+{
+    *ppSymbol = nullptr;
+
+    auto&& children = m_pSymbol->InternalGetChildren();
+
+    while (m_pos < children.size())
+    {
+        BaseSymbol *pBaseSymbol = m_pSymbol->InternalGetSymbolSet()->InternalGetSymbol(children[m_pos]);
+        ++m_pos;
+
+        if (pBaseSymbol == nullptr)
+        {
+            //
+            // Something has gone *SERIOUSLY* wrong if we have a child id that no longer happens to be indexed
+            // by the symbol set!
+            //
+            return E_UNEXPECTED;
+        }
+
+        //
+        // Do we have any additional match criteria...?
+        //
+        //     - Are we searching for a specific symbol kind or any symbol...?
+        //     - Are we searching for a specific symbol by name...?
+        //
+        if (m_kind != SvcSymbol && m_kind != pBaseSymbol->InternalGetKind())
+        {
+            continue;
+        }
+
+        if (!m_name.empty() && m_name != pBaseSymbol->InternalGetName())
+        {
+            continue;
+        }
+
+        ComPtr<ISvcSymbol> spSymbol = pBaseSymbol;
+        *ppSymbol = spSymbol.Detach();
+        return S_OK;
+    }
+
+    return E_BOUNDS;
+}
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger

--- a/TargetComposition/SymBuilder/SymbolBase.h
+++ b/TargetComposition/SymBuilder/SymbolBase.h
@@ -1,0 +1,502 @@
+//**************************************************************************
+//
+// SymbolBase.h
+//
+// The header for our base implementation of symbols within a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMBOLBASE_H__
+#define __SYMBOLBASE_H__
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+class SymbolSet;                        // Forward declaration from SymbolSet.h
+class SymbolBuilderProcess;             // Forward declaration from SymManager.h
+
+//*************************************************
+// Base Symbols:
+//
+
+// BaseSymbol:
+//
+// Our "base class" for all symbols.
+//
+class BaseSymbol :
+    public Microsoft::WRL::Implements<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        ISvcSymbol,
+        ISvcSymbolInfo,
+        ISvcSymbolChildren
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbol:
+    //
+
+    // GetSymbolKind():
+    //
+    // Gets the kind of symbol that this is (e.g.: a field, a base class, a type, etc...)
+    //
+    IFACEMETHOD(GetSymbolKind)(_Out_ SvcSymbolKind *pKind)
+    {
+        *pKind = m_kind;
+        return S_OK;
+    }
+
+    // GetName():
+    //
+    // Gets the name of the symbol (e.g.: MyMethod)
+    //
+    IFACEMETHOD(GetName)(_Out_ BSTR *pSymbolName)
+    {
+        *pSymbolName = nullptr;
+        if (!m_name.empty())
+        {
+            *pSymbolName = SysAllocString(m_name.c_str());
+            return (*pSymbolName == nullptr ? E_OUTOFMEMORY : S_OK);
+        }
+        return E_NOT_SET;
+    }
+
+    // GetQualifiedName():
+    //
+    // Gets the qualified name of the symbol (e.g.: MyNamespace::MyClass::MyMethod)
+    //
+    IFACEMETHOD(GetQualifiedName)(_Out_ BSTR *pQualifiedName)
+    {
+        *pQualifiedName = nullptr;
+        if (!m_qualifiedName.empty())
+        {
+            *pQualifiedName = SysAllocString(m_qualifiedName.c_str());
+            return (*pQualifiedName == nullptr ? E_OUTOFMEMORY : S_OK);
+        }
+        return GetName(pQualifiedName);
+    }
+
+    // GetId():
+    //
+    // Gets an identifier for the symbol which can be used to retrieve the same symbol again.  The
+    // identifier is opaque and has semantics only to the underlying symbol set.
+    //
+    IFACEMETHOD(GetId)(_Out_ ULONG64 *pId)
+    {
+        *pId = m_id;
+        return S_OK;
+    }
+
+    // GetOffset():
+    //
+    // Gets the offset of the symbol (if said symbol has such).  Note that if the symbol has multiple
+    // disjoint address ranges associated with it, this method may return S_FALSE to indicate that the symbol
+    // does not necessarily have a simple "base address" for an offset.
+    //
+    IFACEMETHOD(GetOffset)(_Out_ ULONG64 * /*pSymbolOffset*/)
+    {
+        //
+        // Some derived class is expected to override this!
+        //
+        return E_NOT_SET;
+    }
+
+    //*************************************************
+    // ISvcSymbolInfo:
+    //
+
+    // GetType():
+    //
+    // Gets the type of the symbol.
+    //
+    IFACEMETHOD(GetType)(_COM_Outptr_ ISvcSymbol **ppSymbolType)
+    {
+        //
+        // Some derived class may need to override this.
+        //
+        *ppSymbolType = nullptr;
+        return E_NOTIMPL;
+    }
+
+    // GetLocation()
+    //
+    // Gets the location of the symbol.
+    //
+    IFACEMETHOD(GetLocation)(_Out_ SvcSymbolLocation * /*pLocation*/)
+    {
+        //
+        // Some derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetValue()
+    //
+    // Gets the value of a constant value symbol.  GetLocation will return an indication that the symbol
+    // has a constant value.
+    //
+    // If this method is called on a symbol without a constant value, it will fail.
+    //
+    IFACEMETHOD(GetValue)(_Out_ VARIANT * /*pValue*/)
+    {
+        //
+        // Some derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetAttribute():
+    //
+    // Gets a simple attribute of the symbol.  The type of a given attribute is defined by the attribute
+    // itself.   If the symbol cannot logically provide a value for the attribute, E_NOT_SET should be returned.
+    // If the provider does not implement the attribute for any symbol, E_NOTIMPL should be returned.
+    //
+    IFACEMETHOD(GetAttribute)(_In_ SvcSymbolAttribute /*attr*/,
+                              _Out_ VARIANT * /*pAttributeValue*/)
+    {
+        //
+        // Some derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    //*************************************************
+    // ISvcSymbolChildren:
+    //
+
+    // EnumerateChildren():
+    //
+    // Enumerates all children of the given symbol.
+    //
+    IFACEMETHOD(EnumerateChildren)(_In_ SvcSymbolKind kind,
+                                   _In_opt_z_ PCWSTR pwszName,
+                                   _In_opt_ SvcSymbolSearchInfo *pSearchInfo,
+                                   _COM_Outptr_ ISvcSymbolSetEnumerator **ppChildEnum);
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                           _In_ SvcSymbolKind kind,
+                           _In_ ULONG64 parentId,
+                           _In_opt_ PCWSTR pwszSymbolName = nullptr,
+                           _In_opt_ PCWSTR pwszQualifiedName = nullptr)
+    {
+        //
+        // We cannot let a C++ exception escape.
+        //
+        auto fn = [&]()
+        {
+            m_pSymbolSet = pSymbolSet;
+            m_parentId = parentId;
+            m_kind = kind;
+            if (pwszSymbolName != nullptr)
+            {
+                m_name = pwszSymbolName;
+            }
+            if (pwszQualifiedName != nullptr)
+            {
+                m_qualifiedName = pwszQualifiedName;
+            }
+            return InitializeNewSymbol();
+        };
+        return ConvertException(fn);
+    }
+
+    // NotifyDependentChange():
+    //
+    // Called when something this symbol is dependent upon changes (e.g.: layout, etc...).  Derived classes should
+    // override this method, provide a behavior, and then call the base class.
+    //
+    virtual HRESULT NotifyDependentChange();
+
+    // IsGlobal():
+    //
+    // Returns whether or not the symbol is "global".  A global symbol will be indexed by name.  Child symbols
+    // will not.
+    //
+    virtual bool IsGlobal() const
+    {
+        switch(InternalGetKind())
+        {
+            case SvcSymbolType:
+            case SvcSymbolData:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    // Delete():
+    //
+    // Deletes the symbol.  This does *NOT* guarantee that this OBJECT disappears...  only that it is no longer
+    // linked to the symbol set.  If there are still other symbols which refer to this symbol, they may become
+    // "zombie" symbols.  They will still be there but will not function correctly.
+    //
+    virtual HRESULT Delete();
+
+    // AddChild():
+    //
+    // Adds a symbol as a child of this symbol.
+    //
+    HRESULT AddChild(_In_ ULONG64 uniqueId)
+    {
+        //
+        // We cannot let a C++ exception escape.
+        //
+        auto fn = [&]()
+        {
+            m_children.push_back(uniqueId);
+            return NotifyDependentChange();
+        };
+        return ConvertException(fn);
+    }
+
+    // RemoveChild():
+    //
+    // Removes a symbol as a child of this symbol.
+    //
+    HRESULT RemoveChild(_In_ ULONG64 uniqueId);
+
+    // GetChildPosition():
+    //
+    // Gets the position of a child symbol within this parent.
+    //
+    HRESULT GetChildPosition(_In_ ULONG64 childId, _Out_ ULONG64 *pChildPosition)
+    {
+        size_t idx = 0;
+        while (idx < m_children.size())
+        {
+            if (m_children[idx] == childId)
+            {
+                break;
+            }
+
+            ++idx;
+        }
+
+        if (idx >= m_children.size())
+        {
+            return E_INVALIDARG;
+        }
+
+        *pChildPosition = static_cast<ULONG64>(idx);
+        return S_OK;
+    }
+
+    // MoveChildBefore():
+    //
+    // Moves a child to before another index.  The specified index can either be absolute or can be relative
+    // to a particular symbol kind.
+    //
+    HRESULT MoveChildBefore(_In_ ULONG64 childId, 
+                            _In_ ULONG64 pos,
+                            _In_ SvcSymbolKind relativeTo = SvcSymbol);
+
+    // AddDependentNotify():
+    //
+    // Adds a symbol as a dependent notify symbol.  In other words, if something on our symbol
+    // changes (e.g.: type layout), we must notify any symbol for which this method has been called.
+    //
+    HRESULT AddDependentNotify(_In_ ULONG64 uniqueId)
+    {
+        //
+        // We cannot let a C++ exception escape.
+        //
+        auto fn = [&]()
+        {
+            auto it = m_dependentNotifySymbols.find(uniqueId);
+            if (it == m_dependentNotifySymbols.end())
+            {
+                m_dependentNotifySymbols.insert( { uniqueId, 1 });
+            }
+            else
+            {
+                //
+                // Increment the dependency count so that we know how many dependencies are on this unique
+                // id.  This allows us to track, for instance, something like:
+                //
+                // struct foo
+                // {
+                //     struct bar a;
+                //     struct bar b;
+                // }
+                //
+                // There will be a single "dependency" entry within bar for "foo" as a unique ID.  It will have
+                // a two dependency count.  If "a" or "b" are ever removed from foo, that dependency count would
+                // drop to one.
+                //
+                ++(it->second);
+            }
+
+            return S_OK;
+        };
+        return ConvertException(fn);
+    }
+
+    // RemoveDependentNotify():
+    //
+    // Removes a symbol as a dependent notify symbol.  This effectively undoes a call to AddDependentNotify.
+    //
+    HRESULT RemoveDependentNotify(_In_ ULONG64 uniqueId)
+    {
+        //
+        // We cannot let a C++ exception escape.
+        //
+        auto fn = [&]()
+        {
+            auto it = m_dependentNotifySymbols.find(uniqueId);
+            if (it != m_dependentNotifySymbols.end())
+            {
+                if (it->second == 1)
+                {
+                    m_dependentNotifySymbols.erase(it);
+                }
+                else
+                {
+                    //
+                    // Decrement the dependency count.  See AddDependentNotify for details.
+                    //
+                    --(it->second);
+                }
+            }
+            return S_OK;
+        };
+        return ConvertException(fn);
+    }
+
+    //*************************************************
+    // Internal Accessors:
+    //
+
+    SymbolSet *InternalGetSymbolSet() const { return m_pSymbolSet; }
+    std::wstring const& InternalGetName() const { return m_name; }
+    std::wstring const& InternalGetQualifiedName() const
+    {
+        return m_qualifiedName.empty() ? m_name : m_qualifiedName;
+    }
+    SvcSymbolKind InternalGetKind() const { return m_kind; }
+    ULONG64 InternalGetId() const { return m_id; }
+    ULONG64 InternalGetParentId() const { return m_parentId; }
+    std::vector<ULONG64> const& InternalGetChildren() { return m_children; }
+
+protected:
+
+    // Assigned unique id for the symbol
+    ULONG64 m_id;
+    
+    // Assigned unique id for the parent of this symbol
+    ULONG64 m_parentId;
+
+    // The kind of this symbol
+    SvcSymbolKind m_kind;
+
+    // The names of this symbol
+    std::wstring m_name;
+    std::wstring m_qualifiedName;
+
+    // Index of children of this symbol
+    std::vector<ULONG64> m_children;
+
+    // Index of all symbols which are dependent upon this symbol.  If the layout of a type is modified,
+    // everything which includes that type must be "laid out again".  This is the list of symbols which
+    // must receive that notification.
+    //
+    // Note that this is a map from "unique id" -> "dependency count"
+    //
+    std::unordered_map<ULONG64, ULONG64> m_dependentNotifySymbols;
+
+    // Weak back pointer to our owning symbol set.
+    SymbolSet *m_pSymbolSet;
+
+private:
+
+    // InitializeNewSymbol():
+    //
+    // Called to initialize a new symbol.  This adds it to the symbol set's list, assigns a unique id,
+    // etc...
+    //
+    HRESULT InitializeNewSymbol();
+};
+
+// ChildEnumerator:
+//
+// An enumerator which enumerates children of a given symbol.
+//
+class ChildEnumerator :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        ISvcSymbolSetEnumerator
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolSetEnumerator:
+    //
+
+    IFACEMETHOD(Reset)()
+    {
+        m_pos = 0;
+        return S_OK;
+    }
+
+    IFACEMETHOD(GetNext)(_COM_Outptr_ ISvcSymbol **ppSymbol);
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ BaseSymbol *pSymbol,
+                                   _In_ SvcSymbolKind kind = SvcSymbol,
+                                   _In_opt_ PCWSTR pwszName = nullptr)
+    {
+        //
+        // We cannot let a C++ exception escape.
+        //
+        auto fn = [&]()
+        {
+            m_kind = kind;
+            if (pwszName != nullptr)
+            {
+                m_name = pwszName;
+            }
+            m_spSymbol = pSymbol;
+            m_pSymbol = pSymbol;
+            return Reset();
+        };
+        return ConvertException(fn);
+    }
+
+private:
+
+    Microsoft::WRL::ComPtr<ISvcSymbol> m_spSymbol;
+    BaseSymbol *m_pSymbol;
+    SvcSymbolKind m_kind;
+    std::wstring m_name;
+    size_t m_pos;
+};
+
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger
+
+#endif // __SYMBOLBASE_H__

--- a/TargetComposition/SymBuilder/SymbolBuilderComposition.def
+++ b/TargetComposition/SymBuilder/SymbolBuilderComposition.def
@@ -1,0 +1,5 @@
+EXPORTS
+    DebugExtensionInitialize
+    DebugExtensionCanUnload
+    DebugExtensionUninitialize
+    DebugExtensionUnload

--- a/TargetComposition/SymBuilder/SymbolData.cpp
+++ b/TargetComposition/SymBuilder/SymbolData.cpp
@@ -1,0 +1,406 @@
+//**************************************************************************
+//
+// SymbolData.cpp
+//
+// The implementation of data symbols within a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+using namespace Microsoft::WRL;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+//*************************************************
+// Base Data Symbols:
+//
+
+HRESULT BaseDataSymbol::BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                                       _In_ SvcSymbolKind symKind,
+                                       _In_ ULONG64 owningTypeId,
+                                       _In_ ULONG64 symOffset,
+                                       _In_ ULONG64 symTypeId,
+                                       _In_opt_ PCWSTR pwszName,
+                                       _In_opt_ PCWSTR pwszQualifiedName)
+{
+    HRESULT hr = S_OK;
+
+    //
+    // This does not support the initialization of static fields (at present)
+    //
+    if (pwszQualifiedName != nullptr && symKind == SvcSymbolField)
+    {
+        return E_INVALIDARG;
+    }
+
+    //
+    // Global data does not need an owning type.
+    //
+    BaseSymbol *pOwningType = nullptr;
+    if (symKind != SvcSymbolData)
+    {
+        pOwningType = pSymbolSet->InternalGetSymbol(owningTypeId);
+        if (pOwningType == nullptr || pOwningType->InternalGetKind() != SvcSymbolType)
+        {
+            return E_INVALIDARG;
+        }
+    }
+
+    BaseSymbol *pSymbolType = pSymbolSet->InternalGetSymbol(symTypeId);
+    if (pSymbolType == nullptr || pSymbolType->InternalGetKind() != SvcSymbolType)
+    {
+        return E_INVALIDARG;
+    }
+
+    m_rangeCacheOffset = Uninitialized;
+    m_rangeCacheSize = Uninitialized;
+
+    IfFailedReturn(BaseSymbol::BaseInitialize(pSymbolSet, symKind, owningTypeId, pwszName, pwszQualifiedName));
+
+    m_symTypeId = symTypeId;
+    m_symOffset = symOffset;
+
+    if (pOwningType != nullptr)
+    {
+        IfFailedReturn(pOwningType->AddChild(InternalGetId()));
+    }
+
+    //
+    // Keep track of the type's size and offset so we can recache information about the placement of the data upon
+    // any change in the type.
+    //
+    BaseTypeSymbol *pType = static_cast<BaseTypeSymbol *>(pSymbolType);
+
+    //
+    // Let the symbol set know about the mapping of this symbol <-> address range if it has such.
+    //
+    if (symKind == SvcSymbolData && !InternalIsConstantValue())
+    {
+        ULONG64 start = InternalGetActualSymbolOffset();
+        ULONG64 end = start + pType->InternalGetTypeSize();
+        IfFailedReturn(pSymbolSet->InternalAddSymbolRange(start, end, InternalGetId()));
+        m_rangeCacheOffset = start;
+        m_rangeCacheSize = end - start;
+    }
+
+    //
+    // Setup a chain of dependency:
+    //
+    //     - From the type of this field/base to the field itself
+    //     - From the field/base to the owning type
+    //
+    // This way, changes will cause a recomputation of the layout of the owning type when:
+    //
+    //     - Something about the type of this field/base changes
+    //     - Something about the field/base itself changes (e.g.: a manual change of type / offset / etc...)
+    //
+    IfFailedReturn(pSymbolType->AddDependentNotify(InternalGetId()));
+    IfFailedReturn(AddDependentNotify(owningTypeId));
+
+    return hr;
+}
+
+HRESULT BaseDataSymbol::BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                                       _In_ SvcSymbolKind symKind,
+                                       _In_ ULONG64 owningTypeId,
+                                       _In_ VARIANT *pValue,
+                                       _In_ ULONG64 symTypeId,
+                                       _In_ PCWSTR pwszName,
+                                       _In_opt_ PCWSTR pwszQualifiedName)
+
+{
+    HRESULT hr = S_OK;
+
+    //
+    // Only fields and global data can initialize as a constant value!
+    //
+    if (symKind != SvcSymbolField && symKind != SvcSymbolData)
+    {
+        return E_INVALIDARG;
+    }
+
+    //
+    // We can only deal with certain classes of variant types!
+    //
+    switch(pValue->vt)
+    {
+        case VT_EMPTY:
+            //
+            // A value of VT_EMPTY indicates that it is an automatic increment enumerant.  Make sure
+            // the rest of it looks like an enumerant.
+            //
+            if (symTypeId != 0)
+            {
+                return E_INVALIDARG;
+            }
+            break;
+
+        case VT_I1:
+        case VT_I2:
+        case VT_I4:
+        case VT_I8:
+        case VT_UI1:
+        case VT_UI2:
+        case VT_UI4:
+        case VT_UI8:
+        case VT_R4:
+        case VT_R8:
+        case VT_BOOL:
+            break;
+
+        default:
+            return E_INVALIDARG;
+    }
+
+    // 
+    // Global data does not need to belong to some type.
+    //
+    BaseSymbol *pOwningType = nullptr;
+    if (symKind != SvcSymbolData)
+    {
+        pOwningType = pSymbolSet->InternalGetSymbol(owningTypeId);
+        if (pOwningType == nullptr || pOwningType->InternalGetKind() != SvcSymbolType)
+        {
+            return E_INVALIDARG;
+        }
+    }
+
+    BaseSymbol *pSymbolType = nullptr;
+    if (symTypeId == 0)
+    {
+        //
+        // Only enumerants are allowed to not have a specified type.  Such type will automatically inherit
+        // from the parent enum type.  We must make sure in this case that the parent symbol really is an enum type!
+        //
+        BaseSymbol *pParentSymbol = pSymbolSet->InternalGetSymbol(owningTypeId);
+        if (pParentSymbol == nullptr || pParentSymbol->InternalGetKind() != SvcSymbolType)
+        {
+            return E_INVALIDARG;
+        }
+
+        BaseTypeSymbol *pParentType = static_cast<BaseTypeSymbol *>(pParentSymbol);
+        if (pParentType->InternalGetTypeKind() != SvcSymbolTypeEnum)
+        {
+            return E_INVALIDARG;
+        }
+    }
+    else
+    {
+        pSymbolType = pSymbolSet->InternalGetSymbol(symTypeId);
+        if (pSymbolType == nullptr || pSymbolType->InternalGetKind() != SvcSymbolType)
+        {
+            return E_INVALIDARG;
+        }
+    }
+
+    IfFailedReturn(BaseSymbol::BaseInitialize(pSymbolSet, symKind, owningTypeId, pwszName, pwszQualifiedName));
+
+    m_symTypeId = symTypeId;
+    m_symOffset = (pValue->vt == VT_EMPTY ? UdtPositionalSymbol::AutomaticIncreaseConstantValue 
+                                          : UdtPositionalSymbol::ConstantValue);
+
+    //
+    // NOTE: This is safe and we don't need to do anything like VariantCopy/VariantClear specifically because
+    //       we only allow I1->I8, UI1->UI8, and R4->R8.
+    //
+    //       If this happens to have been VT_EMPTY, we will copy the "empty" notion until LayoutEnum completes.
+    //
+    m_symValue = *pValue;
+
+    if (pOwningType != nullptr)
+    {
+        IfFailedReturn(pOwningType->AddChild(InternalGetId()));
+    }
+
+    //
+    // Setup a chain of dependency:
+    //
+    //     - From the type of this field/base to the field itself
+    //     - From the field/base to the owning type
+    //
+    // This way, changes will cause a recomputation of the layout of the owning type when:
+    //
+    //     - Something about the type of this field/base changes
+    //     - Something about the field/base itself changes (e.g.: a manual change of type / offset / etc...)
+    //
+    if (pSymbolType != nullptr)
+    {
+        IfFailedReturn(pSymbolType->AddDependentNotify(InternalGetId()));
+    }
+    IfFailedReturn(AddDependentNotify(owningTypeId));
+
+    return hr;
+}
+
+HRESULT BaseDataSymbol::Delete()
+{
+    HRESULT hr = S_OK;
+
+    BaseSymbol *pSymbolType = InternalGetSymbolSet()->InternalGetSymbol(m_symTypeId);
+    if (pSymbolType != nullptr)
+    {
+        //
+        // Remove the chains of dependency introduced in our initializer.  We must remove both the chain from
+        // the data type to us and our chain to the owning type.  Note that the latter will disappear automatically
+        // when we are deleted.  In reality, we only need to remove the first here.
+        //
+        IfFailedReturn(pSymbolType->RemoveDependentNotify(InternalGetId()));
+    }
+
+    return BaseSymbol::Delete();
+}
+
+HRESULT BaseDataSymbol::GetType(_COM_Outptr_ ISvcSymbol **ppSymbolType)
+{
+    *ppSymbolType = nullptr;
+
+    BaseSymbol *pSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_symTypeId);
+    if (pSymbol == nullptr)
+    {
+        return E_UNEXPECTED;
+    }
+
+    ComPtr<ISvcSymbol> spSymbol = pSymbol;
+    *ppSymbolType = spSymbol.Detach();
+    return S_OK;
+}
+
+HRESULT BaseDataSymbol::InternalSetSymbolOffset(_In_ ULONG64 symOffset)
+{
+    //
+    // It's *MUCH* easier here if nothing changes.
+    //
+    if (symOffset == m_symOffset)
+    {
+        return S_OK;
+    }
+
+    m_symOffset = symOffset;
+
+    HRESULT hr = NotifyDependentChange();
+
+    // 
+    // Send an advisory notification upwards that everyone should flush caches.  Do not consider this
+    // a failure to create the symbol if something goes wrong.  At worst, an explicit .reload will be
+    // required in the debugger.
+    //
+    (void)InternalGetSymbolSet()->InvalidateExternalCaches();
+
+    return hr;
+}
+
+HRESULT BaseDataSymbol::InternalSetSymbolTypeId(_In_ ULONG64 symTypeId)
+{
+    //
+    // It's *MUCH* easier here if nothing changes.
+    //
+    if (m_symTypeId == symTypeId)
+    {
+        return S_OK;
+    }
+
+    BaseSymbol *pNewSymType = InternalGetSymbolSet()->InternalGetSymbol(symTypeId);
+    if (pNewSymType == nullptr || pNewSymType->InternalGetKind() != SvcSymbolType)
+    {
+        return E_INVALIDARG;
+    }
+
+    //
+    // We need to remove certain chains of dependency and set up new ones.  At the end of the day,
+    // this needs to be as if symTypeId was passed to our initializer.
+    //
+    HRESULT hr = S_OK;
+
+    BaseSymbol *pCurSymType = InternalGetSymbolSet()->InternalGetSymbol(m_symTypeId);
+    if (pCurSymType != nullptr)
+    {
+        IfFailedReturn(pCurSymType->RemoveDependentNotify(InternalGetId()));
+    }
+
+    IfFailedReturn(pNewSymType->AddDependentNotify(InternalGetId()));
+
+    m_symTypeId = symTypeId;
+
+    hr = NotifyDependentChange();
+
+    // 
+    // Send an advisory notification upwards that everyone should flush caches.  Do not consider this
+    // a failure to create the symbol if something goes wrong.  At worst, an explicit .reload will be
+    // required in the debugger.
+    //
+    (void)InternalGetSymbolSet()->InvalidateExternalCaches();
+
+    return hr;
+}
+
+HRESULT BaseDataSymbol::NotifyDependentChange()
+{
+    HRESULT hr = S_OK;
+
+    //
+    // If something like the underlying type changed, recompute the size and, if that has changed, send
+    // a notification to the symbol set so that it can recache symbol information.
+    //
+    if (m_symTypeId != 0 && InternalGetKind() == SvcSymbolData)
+    {
+        BaseSymbol *pSymbolType = InternalGetSymbolSet()->InternalGetSymbol(m_symTypeId);
+        if (pSymbolType != nullptr && pSymbolType->InternalGetKind() == SvcSymbolType)
+        {
+            BaseTypeSymbol *pType = static_cast<BaseTypeSymbol *>(pSymbolType);
+            ULONG64 typeSize = pType->InternalGetTypeSize();
+            ULONG64 newStart = InternalGetActualSymbolOffset();
+
+            if (m_rangeCacheOffset != Uninitialized && m_rangeCacheSize != Uninitialized &&
+                (newStart != m_rangeCacheOffset || typeSize != m_rangeCacheSize))
+            {
+                IfFailedReturn(InternalGetSymbolSet()->InternalRemoveSymbolRange(m_rangeCacheOffset,
+                                                                                 m_rangeCacheOffset + m_rangeCacheSize,
+                                                                                 InternalGetId()));
+            }
+
+            if (newStart != m_rangeCacheOffset || typeSize != m_rangeCacheSize)
+            {
+                ULONG64 newEnd = newStart + typeSize;
+                IfFailedReturn(InternalGetSymbolSet()->InternalAddSymbolRange(newStart, newEnd, InternalGetId()));
+                m_rangeCacheOffset = newStart;
+                m_rangeCacheSize = newEnd - newStart;
+            }
+        }
+    }
+
+    return BaseSymbol::NotifyDependentChange();
+}
+
+//*************************************************
+// Global Data:
+//
+
+HRESULT GlobalDataSymbol::RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                                 _In_ ULONG64 parentId,
+                                                 _In_ ULONG64 dataOffset,
+                                                 _In_ ULONG64 dataTypeId,
+                                                 _In_ PCWSTR pwszName,
+                                                 _In_opt_ PCWSTR pwszQualifiedName)
+{
+    return BaseInitialize(pSymbolSet, SvcSymbolData, parentId, dataOffset, dataTypeId, pwszName, pwszQualifiedName);
+}
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger

--- a/TargetComposition/SymBuilder/SymbolData.h
+++ b/TargetComposition/SymBuilder/SymbolData.h
@@ -1,0 +1,236 @@
+//**************************************************************************
+//
+// SymbolData.h
+//
+// The header for our implementation of global data within a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMBOLDATA_H__
+#define __SYMBOLDATA_H__
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+// BaseDataSymbol:
+//
+// Base class for a variety of data symbols (e.g.: fields, enumerants, global variables, etc...)
+//
+class BaseDataSymbol : 
+    public Microsoft::WRL::Implements<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseSymbol
+        >
+{
+public:
+
+    // ConstantValue:
+    //
+    // A constant used for the field offsets which indicates that this field has a constant value and
+    // no other location.
+    //
+    static constexpr ULONG64 ConstantValue = static_cast<ULONG64>(-1ll);
+
+    //*************************************************
+    // ISvcSymbol:
+    //
+
+    // GetValue()
+    //
+    // Gets the value of a constant value symbol.  GetLocation will return an indication that the symbol
+    // has a constant value.
+    //
+    // If this method is called on a symbol without a constant value, it will fail.
+    //
+    IFACEMETHOD(GetValue)(_Out_ VARIANT *pValue)
+    {
+        if (!InternalIsConstantValue())
+        {
+            return E_NOTIMPL;
+        }
+
+        //
+        // NOTE: This does *NOT* require a VariantCopy or the like because we only support a very limited
+        //       subset of variant values.
+        //
+        *pValue = m_symValue;
+        return S_OK;
+    }
+
+    // GetOffset():
+    //
+    // Gets the offset of the symbol (if said symbol has such).  Note that if the symbol has multiple
+    // disjoint address ranges associated with it, this method may return S_FALSE to indicate that the symbol
+    // does not necessarily have a simple "base address" for an offset.
+    //
+    IFACEMETHOD(GetOffset)(_Out_ ULONG64 *pSymbolOffset)
+    {
+        *pSymbolOffset = m_symOffset;
+        return S_OK;
+    }
+
+    //*************************************************
+    // ISvcSymbolInfo:
+    //
+
+    // GetType():
+    //
+    // Gets the type of the symbol.
+    //
+    IFACEMETHOD(GetType)(_COM_Outptr_ ISvcSymbol **ppSymbolType);
+
+    // GetLocation()
+    //
+    // Gets the location of the symbol.
+    //
+    IFACEMETHOD(GetLocation)(_Out_ SvcSymbolLocation *pLocation)
+    {
+        //
+        // If the field has a constant value, indicate this.
+        //
+        if (InternalIsConstantValue())
+        {
+            pLocation->Kind = SvcSymbolLocationConstantValue;
+            return S_OK;
+        }
+
+        //
+        // The offset for global data is relative to the base of the module (where it loaded).  The offset
+        // for a field is relative to the beginning of the structure (unless it is static).
+        //
+        pLocation->Kind = (InternalGetKind() == SvcSymbolData ? SvcSymbolLocationImageOffset :
+                                                                SvcSymbolLocationStructureRelative);
+
+        pLocation->Offset = InternalGetActualSymbolOffset();
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    // BaseInitialize():
+    //
+    // Initialize the data symbol (as an offset based symbol).  This offset is either relative to some structure
+    // (e.g.: it is a field) or is relative to the base address of the module (e.g.: it is global data)
+    //
+    HRESULT BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                           _In_ SvcSymbolKind symKind,
+                           _In_ ULONG64 owningTypeId,
+                           _In_ ULONG64 symOffset,
+                           _In_ ULONG64 symTypeId,
+                           _In_opt_ PCWSTR pwszName,
+                           _In_opt_ PCWSTR pwszQualifiedName);
+
+    // BaseInitialize():
+    //
+    // Initialize the data symbol (as a value based symbol).  Only fields and global data can initialize
+    // in this way!
+    //
+    HRESULT BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                           _In_ SvcSymbolKind symKind,
+                           _In_ ULONG64 owningTypeId,
+                           _In_ VARIANT *pValue,
+                           _In_ ULONG64 symTypeId,
+                           _In_ PCWSTR pwszName,
+                           _In_opt_ PCWSTR pwszQualifiedName);
+
+    // Delete():
+    //
+    // Called when the data symbol is deleted.
+    //
+    virtual HRESULT Delete();
+
+    // NotifyDependentChange():
+    //
+    // Called when something this symbol is dependent upon changes (e.g.: layout, etc...).  If our underlying
+    // type changed, we need to refetch the size and subsequently pass a notification to the symbol set so that
+    // it can update its mapping of symbol <-> offset.
+    //
+    virtual HRESULT NotifyDependentChange();
+
+    //*************************************************
+    // Internal Accessors:
+    //
+
+    virtual bool InternalIsConstantValue() const { return m_symOffset == ConstantValue; }
+    virtual bool InternalHasType() const { return m_symTypeId != 0; }
+
+    virtual ULONG64 InternalGetSymbolTypeId() const { return m_symTypeId; }
+    virtual ULONG64 InternalGetSymbolOffset() const { return m_symOffset; }
+    virtual ULONG64 InternalGetActualSymbolOffset() const { return m_symOffset; }
+    virtual VARIANT const& InternalGetSymbolValue() const { return m_symValue; }
+
+    //*************************************************
+    // Internal  Setters:
+    //
+
+    virtual HRESULT InternalSetSymbolTypeId(_In_ ULONG64 symTypeId);
+    virtual HRESULT InternalSetSymbolOffset(_In_ ULONG64 symOffset);
+
+protected:
+
+
+    ULONG64 m_symTypeId;                // What is the **SYMBOL'S** type (enumerants will not have this)
+    ULONG64 m_symOffset;                // Either hard coded or ConstantValue (derived classes may add to this)
+    VARIANT m_symValue;                 // Relevant only for constant valued fields
+
+    //
+    // Caches for symbol ranges:
+    //
+
+    // Uninitialized:
+    //
+    // Indicates that a cached value is uninitialized.
+    //
+    static constexpr ULONG64 Uninitialized = static_cast<ULONG64>(-1ll);
+
+    ULONG64 m_rangeCacheOffset;         // How the symbol's range map is currently registered: base offset
+    ULONG64 m_rangeCacheSize;           // How the symbol's range map is currently registered: size
+};
+
+// GlobalDataSymbol:
+//
+// Represents global data within a module (e.g.: a global variable)
+//
+class GlobalDataSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseDataSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 parentId,
+                                   _In_ ULONG64 dataOffset,
+                                   _In_ ULONG64 dataTypeId,
+                                   _In_ PCWSTR pwszName,
+                                   _In_opt_ PCWSTR pwszQualifiedName);
+
+
+};
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger
+
+#endif // __SYMBOLDATA_H__

--- a/TargetComposition/SymBuilder/SymbolServices.cpp
+++ b/TargetComposition/SymBuilder/SymbolServices.cpp
@@ -1,0 +1,65 @@
+//**************************************************************************
+//
+// SymbolServices.cpp
+//
+// Services related to providing symbols.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+using namespace Microsoft::WRL;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+HRESULT SymbolProvider::LocateSymbolsForImage(_In_ ISvcModule *pImage,
+                                              _COM_Outptr_ ISvcSymbolSet **ppSymbolSet)
+{
+    HRESULT hr = S_OK;
+    *ppSymbolSet = nullptr;
+
+    //
+    // Be a good citizen if there are multiple symbol providers in the container.  In such cases, we are expected
+    // to return E_UNHANDLED_REQUEST_TYPE if the symbol format isn't one that we support.  Given that we are
+    // "on demand" and only when created by an API, this should be **OUR** default error code.  It may not be the
+    // default error code of some other symbol provider.
+    //
+    // E_UNHANDLED_REQUEST_TYPE generally means "not me...  move on to the next provider in order"
+    //
+
+    if (m_spSymManager == nullptr)
+    {
+        return E_UNHANDLED_REQUEST_TYPE;
+    }
+
+    ULONG64 moduleKey;
+    IfFailedReturn(pImage->GetKey(&moduleKey));
+
+    ComPtr<SymbolBuilderProcess> spSymProcess;
+    IfFailedReturn(m_spSymManager->TrackProcessForModule(pImage, &spSymProcess));
+
+    ComPtr<SymbolSet> spSymbolSet;
+    if (spSymProcess->TryGetSymbolsForModule(moduleKey, &spSymbolSet))
+    {
+        *ppSymbolSet = spSymbolSet.Detach();
+        return S_OK;
+    }
+
+    return E_UNHANDLED_REQUEST_TYPE;
+}
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger

--- a/TargetComposition/SymBuilder/SymbolServices.h
+++ b/TargetComposition/SymBuilder/SymbolServices.h
@@ -1,0 +1,206 @@
+//**************************************************************************
+//
+// SymbolServices.h
+//
+// Services related to providing symbols.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMBOLSERVICES_H__
+#define __SYMBOLSERVICES_H__
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+// SymbolProvider:
+//
+// Our "symbol provider" service.  Any time the debugger goes and looks for symbols for a particular module, it
+// will look to see if there is a symbol provider in the service container.  If so, it will call it to ask whether
+// or not it wants to provide symbols.
+//
+// Note that multiple symbol providers can be aggregated together and can be asked, each in turn, whether they 
+// have symbols for a particular module.
+//
+class SymbolProvider :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        IDebugServiceLayer,
+        ISvcSymbolProvider
+        >
+{
+public:
+
+    //*************************************************
+    // IDebugServiceLayer:
+    //
+
+    // RegisterServices():
+    //
+    // Registers all services contained in this component with the services manager.
+    //
+    IFACEMETHOD(RegisterServices)(_In_ IDebugServiceManager *pServiceManager)
+    {
+        HRESULT hr = S_OK;
+        IfFailedReturn(pServiceManager->RegisterService(DEBUG_SERVICE_SYMBOL_PROVIDER, this));
+        return hr;
+    }
+
+    // GetServiceDependencies():
+    //
+    // Returns the set of services which this service layer / component depends on.  Having sizeHardDependencies or
+    // sizeSoftDependencies set to 0 will pass back the number of dependencies and do nothing else.
+    //
+    IFACEMETHOD(GetServiceDependencies)(_In_ ServiceNotificationKind /*notificationKind*/,
+                                        _In_ IDebugServiceManager * /*pServiceManager*/,
+                                        _In_ REFGUID /*serviceGuid*/,
+                                        _In_ ULONG64 sizeHardDependencies,
+                                        _Out_writes_(sizeHardDependencies) GUID *pHardDependencies,
+                                        _Out_ ULONG64 *pNumHardDependencies,
+                                        _In_ ULONG64 sizeSoftDependencies,
+                                        _Out_writes_(sizeSoftDependencies) GUID * /*pSoftDependencies*/,
+                                        _Out_ ULONG64 *pNumSoftDependencies)
+    {
+        HRESULT hr = S_OK;
+        if (sizeHardDependencies == 0 && sizeSoftDependencies == 0)
+        {
+            *pNumHardDependencies = 1;
+            *pNumSoftDependencies = 0;
+            return S_OK;
+        }
+
+        if (sizeHardDependencies < 1)
+        {
+            return E_INVALIDARG;
+        }
+
+        pHardDependencies[0] = DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER;
+
+        *pNumHardDependencies = 1;
+        *pNumSoftDependencies = 0;
+        return hr;
+    }
+
+    // InitializeServices():
+    //
+    // Performs initialization of the services in a service layer / component.  Services which aggregate, 
+    // encapsulate, or stack on top of other services must pass down the initialization notification in an 
+    // appropriate manner (with notificationKind set to LayeredNotification).
+    //
+    IFACEMETHOD(InitializeServices)(_In_ ServiceNotificationKind /*notificationKind*/,
+                                    _In_ IDebugServiceManager *pServiceManager,
+                                    _In_ REFIID /*serviceGuid*/)
+    {
+        HRESULT hr = S_OK;
+
+        //
+        // We have a hard dependency on the symbol builder manager.
+        //
+        //     1) If we are inserted into the service container *PRIOR* to its spin up (e.g.: as part
+        //        of a file activation), it is guaranteed to be in the service container and initialized
+        //        by this point (initialization follows the ordering of a DAG of dependencies).
+        //
+        //     2) If we are inserted into the service container dynamically, there **IS NO GUARANTEE** that
+        //        the process enumeration service is there despite the dependency.  As we load in a dynamic
+        //        fashion, we must be prepared to deal with this!  Hence, we do *NOT* fail initialization
+        //        and all our calls check m_spProcEnum.
+        //
+        (void)pServiceManager->QueryService(DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER, IID_PPV_ARGS(&m_spSymManager));
+
+        return hr;
+    }
+
+    // NotifyServiceChange():
+    //
+    // Called when there is a change in the component registered as a service in the
+    // target composition stack.
+    //
+    IFACEMETHOD(NotifyServiceChange)(_In_ ServiceNotificationKind /*notificationKind*/,
+                                     _In_ IDebugServiceManager * /*pServiceManager*/,
+                                     _In_ REFIID serviceGuid,
+                                     _In_opt_ IDebugServiceLayer * /*pPriorService*/,
+                                     _In_opt_ IDebugServiceLayer *pNewService)
+    {
+        HRESULT hr = S_OK;
+        if (serviceGuid == DEBUG_PRIVATE_SERVICE_SYMBOLBUILDER_MANAGER)
+        {
+            //
+            // If the symbol builder manager service changed, alter our cached copy of it so that we are calling
+            // the correct service!
+            //
+            m_spSymManager = nullptr;
+            if (pNewService != nullptr)
+            {
+                //
+                // We *MUST* support that interface.  In reality, no one should come in and change this since it's
+                // a private interface that only we know about.  But still...
+                //
+                IfFailedReturn(pNewService->QueryInterface(IID_PPV_ARGS(&m_spSymManager)));
+            }
+        }
+
+        return hr;
+    }
+
+    // NotifyEvent():
+    //
+    // Called to notify this component that an event of interest occurred.
+    //
+    IFACEMETHOD(NotifyEvent)(_In_ IDebugServiceManager * /*pServiceManager*/,
+                             _In_ REFIID /*eventGuid*/,
+                             _In_opt_ IUnknown * /*pEventArgument*/)
+    {
+        return S_OK;
+    }
+
+    //*************************************************
+    // ISvcSymbolProvider:
+    //
+
+    // LocateSymbolsForImage():
+    //
+    // For a given image (identified by an ISvcModule), find the set of symbolic information available for the image
+    // and return a symbol set.
+    //
+    IFACEMETHOD(LocateSymbolsForImage)(_In_ ISvcModule *pImage,
+                                       _COM_Outptr_ ISvcSymbolSet **ppSymbolSet);
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    // RuntimeClassInitialize():
+    //
+    // Initializes a new symbol builder symbol provider.
+    //
+    HRESULT RuntimeClassInitialize()
+    {
+        return S_OK;
+    }
+
+private:
+
+    //
+    // Cached copy of the symbol builder manager that we placed in the container.  This tracks
+    // everything associated with what symbols we have constructed, etc...
+    //
+    Microsoft::WRL::ComPtr<ISvcSymbolBuilderManager> m_spSymManager;
+
+};
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger
+
+#endif // __SYMBOLSERVICES_H__
+

--- a/TargetComposition/SymBuilder/SymbolSet.cpp
+++ b/TargetComposition/SymBuilder/SymbolSet.cpp
@@ -1,0 +1,702 @@
+//**************************************************************************
+//
+// SymbolSet.cpp
+//
+// The implementation for our notion of a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+using namespace Microsoft::WRL;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+//*************************************************
+// General Symbol Set:
+//
+
+bool SymbolRangeList::FindSymbols(_In_ ULONG64 address, _Out_ SymbolList const** pSymbolList)
+{
+    auto it = std::lower_bound(m_ranges.begin(), m_ranges.end(), address,
+                               [&](_In_ const AddressRange& rng, _In_ ULONG64 address)
+                               {
+                                   return rng.End < address;
+                               });
+
+    if (it == m_ranges.end() || it->Start > address)
+    {
+        return false;
+    }
+
+    *pSymbolList = &(it->Symbols);
+    return true;
+}
+
+HRESULT SymbolRangeList::AddSymbol(_In_ ULONG64 start, _In_ ULONG64 end, _In_ ULONG64 symbol)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        //
+        // We must find the proper position within the address range to place the symbol in sorted
+        // order.  If there is no overlap, this is easy.  If there is overlap, we must split the ranges
+        // as appropriate.
+        //
+        auto it = std::lower_bound(m_ranges.begin(), m_ranges.end(), start,
+                                   [&](_In_ const AddressRange& rng, _In_ ULONG64 address)
+                                   {
+                                       return rng.End < address;
+                                   });
+
+        //
+        // If there are no address ranges which begin above 'start', just append the range and be done.
+        // Likewise, if there is *AND* there is no overlap with any other known address range, just insert
+        // the new range before the one which is greater.
+        //
+        if (it == m_ranges.end())
+        {
+            m_ranges.push_back( { start, end, { symbol } } );
+            return S_OK;
+        }
+
+        if (end <= it->Start)
+        {
+            m_ranges.insert(it, { start, end, { symbol } } );
+            return S_OK;
+        }
+
+        //
+        // At this point, there is at least some overlap.  Walk forward, adding symbol to the ranges where
+        // appropriate and splitting where not.
+        //
+        size_t cur = it - m_ranges.begin();
+        while (start < end)
+        {
+            //
+            // If we have gotten to the point where there's nothing left and we still have range, append it.
+            //
+            if (cur >= m_ranges.size())
+            {
+                m_ranges.push_back( { start, end, { symbol } });
+                start = end;
+                break;
+            }
+
+            AddressRange& rng = m_ranges[cur];
+            
+            //
+            // If there is 100% overlap, just add the new symbol and be done.
+            //
+            if (start == rng.Start && end == rng.End)
+            {
+                rng.Symbols.push_back(symbol);
+                start = end;
+                break;
+            }
+
+            //
+            // If there is a part of the range before rng, insert it and continue on.
+            //
+            if (start < rng.Start)
+            {
+                ULONG64 curEnd = end;
+                if (curEnd > rng.Start)
+                {
+                    curEnd = rng.Start;
+                }
+
+                if (curEnd - start > 0)
+                {
+                    m_ranges.insert(m_ranges.begin() + cur, { start, curEnd, { symbol } });
+                    ++cur;
+                    start = curEnd;
+                    continue;
+                }
+            }
+
+            if (start >= rng.Start && start < rng.End)
+            {
+                //
+                // There is overlap.  Start is within the range.  End may be within the range *OR* it may be
+                // outside of the range.  We need to split the range.  There are three split points:
+                //
+                // 1: [rng.Start, start)
+                // 2: [start, end)
+                // 3: [end, rng.End)
+                //
+                // Note that if end goes outside the bounds of rng, there are only two:
+                //
+                // 1: [rng.Start, start)
+                // 2: [start, rng.End)
+                //
+                // But in the latter case, we will have to loop back up and continue with whatever was outside
+                // the bounds of rng.
+                //
+                if (start > rng.Start)
+                {
+                    auto itn = m_ranges.insert(m_ranges.begin() + cur, { rng.Start, start, rng.Symbols } );
+                    ++cur;
+                    AddressRange& existingRange = m_ranges[cur];
+                    existingRange.Start = start;
+                    continue;
+                }
+                else if (end >= rng.End)
+                {
+                    rng.Symbols.push_back(symbol);
+                    start = rng.End;
+                    ++cur;
+                    continue;
+                }
+                else
+                {
+                    //
+                    // We need to split again -- this is that #2 range in the first case above.  First, add
+                    // the new range for #3
+                    //
+                    auto itb = m_ranges.begin() + cur + 1;
+                    m_ranges.insert(itb, { end, rng.End, rng.Symbols });
+                    AddressRange& existingRange = m_ranges[cur];
+                    existingRange.End = end;
+                    existingRange.Symbols.push_back(symbol);
+                    start = end;
+                    break;
+                }
+            }
+            else
+            {
+                //
+                // It's not this range.  Move onto the next one.
+                //
+                ++cur;
+                continue;
+            }
+        }
+
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT SymbolRangeList::RemoveSymbol(_In_ ULONG64 start, _In_ ULONG64 end, _In_ ULONG64 symbol)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        //
+        // Find where the first range associated with this symbol is and remove everything between
+        // [start, end)
+        //
+        auto it = std::lower_bound(m_ranges.begin(), m_ranges.end(), start,
+                                   [&](_In_ const AddressRange& rng, _In_ ULONG64 start)
+                                   {
+                                       return rng.End < start;
+                                   });
+
+        if (it == m_ranges.end() || it->Start > end)
+        {
+            //
+            // We could not find this range.  It's not a failure per-se.  Just return S_FALSE to the caller
+            // to let them know nothing was actually removed!
+            //
+            return S_FALSE;
+        }
+
+        //
+        // We need to keep walking and removing symbols or splitting ranges until we hit a range which is
+        // past the end of the sought half-open set [start, end)
+        //
+        size_t cur = it - m_ranges.begin();
+        while (cur < m_ranges.size() && end > m_ranges[cur].Start)
+        {
+            AddressRange& rng = m_ranges[cur];
+
+            //
+            // If the range is equivalent or a sub-range, just remove the symbol
+            //
+            if (start <= rng.Start && end >= rng.End)
+            {
+                RemoveSymbolFromList(rng.Symbols, symbol);
+                ++cur;
+                continue;
+            }
+
+            //
+            // If there is a sub-portion at the beginning of the range that we are *NOT* removing the
+            // symbol index from, we need to split.
+            //
+            // This would be something like:
+            //
+            //     range:   [              )
+            //    remove:         [        )
+            //
+            // Where we now need:
+            //
+            //    range1:   [     )                 <-- has symbol
+            //    range2:         [        )        <-- does not have symbol
+            //
+            if (start > rng.Start && start < rng.End)
+            {
+                auto itb = m_ranges.begin() + cur + 1;
+                auto itn = m_ranges.insert(itb, { start, rng.End, rng.Symbols } );      // range2
+                RemoveSymbolFromList(itn->Symbols, symbol);
+
+                AddressRange& existingRange = m_ranges[cur];
+                existingRange.End = start;
+                ++cur;
+                continue;
+            }
+
+            //
+            // Now we need to check the other side of this (the above will fall into this after the split and continue)
+            //
+            // We may need a further split having something like:
+            //
+            //     range:   [              )
+            //    remove:   [        )
+            //
+            // Where we now need:
+            //
+            //    range1:   [        )              <-- does not have symbol
+            //    range2:            [     )        <-- has symbol
+            //
+            else if (end > rng.Start && end < rng.End)
+            {
+                auto itb = m_ranges.begin() + cur + 1;
+                auto itn = m_ranges.insert(itb, { end, rng.End, rng.Symbols });      // range2
+
+                AddressRange& existingRange = m_ranges[cur];
+                existingRange.End = end;
+                RemoveSymbolFromList(existingRange.Symbols, symbol);
+                ++cur;
+                continue;
+            }
+
+            break;
+        }
+
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+IDebugServiceManager* SymbolSet::GetServiceManager() const
+{
+    return m_pOwningProcess->GetServiceManager();
+}
+
+ISvcMachineArchitecture* SymbolSet::GetArchInfo() const
+{
+    return m_pOwningProcess->GetArchInfo();
+}
+
+HRESULT SymbolSet::AddBasicCTypes()
+{
+    HRESULT hr = S_OK;
+
+    ComPtr<BasicTypeSymbol> spNew;
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicVoid, 0, L"void"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicBool, 1, L"bool"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicChar, 1, L"char"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicUInt, 1, L"unsigned char"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicWChar, 2, L"wchar_t"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicInt, 2, L"short"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicUInt, 2, L"unsigned short"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicInt, 4, L"int"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicUInt, 4, L"unsigned int"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicInt, 8, L"__int64"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicUInt, 8, L"unsigned __int64"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicLong, 4, L"long"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicULong, 4, L"unsigned long"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicFloat, 4, L"float"));
+    IfFailedReturn(MakeAndInitialize<BasicTypeSymbol>(&spNew, this, SvcSymbolIntrinsicFloat, 8, L"double"));
+
+    return hr;
+}
+
+HRESULT SymbolSet::AddNewSymbol(_In_ BaseSymbol *pBaseSymbol, _Out_ ULONG64 *pUniqueId)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        ULONG64 uniqueId = GetUniqueId();
+        if (m_symbols.size() <= uniqueId + 1)
+        {
+            m_symbols.resize(static_cast<size_t>(uniqueId + 1));
+        }
+
+        m_symbols[uniqueId] = pBaseSymbol;
+
+        if (pBaseSymbol->IsGlobal())
+        {
+            m_globalSymbols.push_back(uniqueId);
+            if (!pBaseSymbol->InternalGetQualifiedName().empty())
+            {
+                m_symbolNameMap.insert( { pBaseSymbol->InternalGetQualifiedName(), uniqueId });
+            }
+        }
+
+        *pUniqueId = uniqueId;
+
+        // 
+        // Send an advisory notification upwards that everyone should flush caches.  Do not consider this
+        // a failure to create the symbol if something goes wrong.  At worst, an explicit .reload will be
+        // required in the debugger.
+        //
+        (void)InvalidateExternalCaches();
+
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT SymbolSet::DeleteExistingSymbol(_In_ ULONG64 uniqueId)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        //
+        // As we hand out 'uniqueId' based on position within a vector, it should always fit within the
+        // bounds of a size_t.  
+        //
+        if (uniqueId > std::numeric_limits<size_t>::max())
+        {
+            return E_INVALIDARG;
+        }
+
+        BaseSymbol *pSymbol = InternalGetSymbol(uniqueId);
+        if (pSymbol != nullptr)
+        {
+            if (pSymbol->IsGlobal())
+            {
+                for (auto itg = m_globalSymbols.begin(); itg != m_globalSymbols.end(); ++itg)
+                {
+                    if (*itg == uniqueId)
+                    {
+                        m_globalSymbols.erase(itg);
+                        break;
+                    }
+                }
+
+                if (!pSymbol->InternalGetQualifiedName().empty())
+                {
+                    auto itn = m_symbolNameMap.find(pSymbol->InternalGetQualifiedName());
+                    if (itn != m_symbolNameMap.end())
+                    {
+                        m_symbolNameMap.erase(itn);
+                    }
+                }
+            }
+
+            m_symbols[static_cast<size_t>(uniqueId)] = nullptr;
+
+            //
+            // Send an advisory notification upwards that everyone should flush caches.  Do not consider this
+            // a failure to delete the symbol if something goes wrong.  At worst, an explicit .reload will be
+            // required by the debugger.
+            //
+            (void)InvalidateExternalCaches();
+        }
+
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT SymbolSet::EnumerateAllSymbols(_COM_Outptr_ ISvcSymbolSetEnumerator **ppEnumerator)
+{
+    HRESULT hr = S_OK;
+    *ppEnumerator = nullptr;
+
+    ComPtr<GlobalEnumerator> spEnum;
+    IfFailedReturn(MakeAndInitialize<GlobalEnumerator>(&spEnum, this));
+
+    *ppEnumerator = spEnum.Detach();
+    return hr;
+}
+
+HRESULT SymbolSet::InvalidateExternalCaches()
+{
+    HRESULT hr = S_OK;
+
+    IDebugServiceManager *pServiceManager = GetServiceManager();
+    if (pServiceManager == nullptr)
+    {
+        return E_UNEXPECTED;
+    }
+
+    ComPtr<SymbolCacheInvalidateArguments> spArgs;
+    IfFailedReturn(MakeAndInitialize<SymbolCacheInvalidateArguments>(&spArgs, m_spModule.Get(), this));
+
+    HRESULT hrEvent;
+    IfFailedReturn(pServiceManager->FireEventNotification(DEBUG_SVCEVENT_SYMBOLCACHEINVALIDATE, spArgs.Get(), &hrEvent));
+
+    //
+    // While we get a sink result if some handler decided to return a failure from their handling of the event, we
+    // are not going to propagate that upwards.  There's not really much we can do in this case.
+    //
+    return hr;
+}
+
+HRESULT SymbolSet::FindTypeByName(_In_ std::wstring const& typeName,
+                                  _Out_ ULONG64 *pTypeId,
+                                  _Outptr_ BaseTypeSymbol **ppTypeSymbol,
+                                  _In_ bool allowAutoCreations)
+{
+    HRESULT hr = S_OK;
+
+    if (ppTypeSymbol != nullptr)
+    {
+        *ppTypeSymbol = nullptr;
+    }
+
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        ULONG64 symId = InternalGetSymbolIdByName(typeName);
+        BaseSymbol *pSymbol = nullptr;
+        if (symId != 0)
+        {
+            pSymbol = InternalGetSymbol(symId);
+            if (pSymbol == nullptr || pSymbol->InternalGetKind() != SvcSymbolType)
+            {
+                return E_INVALIDARG;
+            }
+
+            *pTypeId = symId;
+
+            if (ppTypeSymbol != nullptr)
+            {
+                *ppTypeSymbol = static_cast<BaseTypeSymbol *>(pSymbol);
+            }
+
+            return hr;
+        }
+        else if (!allowAutoCreations)
+        {
+            return E_INVALIDARG;
+        }
+
+        //
+        // Is this a pointer type or something similar which we will allow "on demand" creation of according
+        // to standard C like semantics.
+        //
+        wchar_t const *pStart = typeName.c_str();
+        wchar_t const *pc = (pStart + wcslen(pStart) - 1);
+
+        switch(*pc)
+        {
+            case L'*':
+            case L'&':
+            case L'^':
+            {
+                if (!m_demandCreatePointerTypes)
+                {
+                    return E_FAIL;
+                }
+
+                SvcSymbolPointerKind pointerKind = SvcSymbolPointerStandard;
+                if (*pc == L'&')
+                {
+                    if (*(pc - 1) == L'&' && (pc - 1) != pStart)
+                    {
+                        --pc;
+                        pointerKind = SvcSymbolPointerRValueReference;
+                    }
+                    else
+                    {
+                        pointerKind = SvcSymbolPointerReference;
+                    }
+                }
+                else if (*pc == L'^')
+                {
+                    pointerKind = SvcSymbolPointerCXHat;
+                }
+
+                wchar_t const *pPrior = (pc - 1);
+                while (pPrior > pStart && iswspace(*pPrior)) { --pPrior; }
+
+                if (pPrior == pStart)
+                {
+                    return E_INVALIDARG;
+                }
+
+                std::wstring baseName(pStart, pPrior - pStart + 1);
+
+                ULONG64 pointedToId = 0;
+                IfFailedReturn(FindTypeByName(baseName, &pointedToId, nullptr));
+
+                ComPtr<PointerTypeSymbol> spPointerType;
+                IfFailedReturn(MakeAndInitialize<PointerTypeSymbol>(&spPointerType, this, pointedToId, pointerKind));
+
+                symId = spPointerType->InternalGetId();
+
+                //
+                // NOTE: This is safe to be held past the ComPtr destruction above because creation of the symbol
+                //       will add it to our internal management lists...  and nothing could possibly have deleted
+                //       it before returning from this method!
+                //
+                pSymbol = spPointerType.Get();
+
+                break;
+            }
+
+            case L']':
+            {
+                if (!m_demandCreateArrayTypes)
+                {
+                    return E_FAIL;
+                }
+
+                wchar_t const *pb = pc - 1;
+                while (pb > pStart && *pb != L'[')
+                {
+                    --pb;
+                }
+
+                if (pb == pStart)
+                {
+                    return E_INVALIDARG;
+                }
+
+                ULONG64 dim = 0;
+                wchar_t const *pDig = pb + 1;
+                while (*pDig != L']')
+                {
+                    if (*pDig >= L'0' && *pDig <= L'9')
+                    {
+                        dim = (dim * 10) + (*pDig - L'0');
+                    }
+                    else
+                    {
+                        return E_INVALIDARG;
+                    }
+                    ++pDig;
+                }
+
+                std::wstring baseName(pStart, pb - pStart);
+
+                ULONG64 arrayOfId = 0;
+                IfFailedReturn(FindTypeByName(baseName, &arrayOfId, nullptr));
+
+                ComPtr<ArrayTypeSymbol> spArrayType;
+                IfFailedReturn(MakeAndInitialize<ArrayTypeSymbol>(&spArrayType, this, arrayOfId, dim));
+
+                symId = spArrayType->InternalGetId();
+
+                //
+                // NOTE: This is safe to be held past the ComPtr destruction above because creation of the symbol
+                //       will add it to our internal management lists...  and nothing could possibly have deleted
+                //       it before returning from this method!
+                //
+                pSymbol = spArrayType.Get();
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        if (symId == 0)
+        {
+            return E_INVALIDARG;
+        }
+
+        if (ppTypeSymbol != nullptr)
+        {
+            *ppTypeSymbol = static_cast<BaseTypeSymbol *>(pSymbol);
+        }
+
+        return hr;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT SymbolSet::FindSymbolByName(_In_ PCWSTR symbolName, _COM_Outptr_ ISvcSymbol **ppSymbol)
+{
+    *ppSymbol = nullptr;
+
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        std::wstring name = symbolName;
+        auto it = m_symbolNameMap.find(name);
+        if (it == m_symbolNameMap.end())
+        {
+            return E_BOUNDS;
+        }
+
+        BaseSymbol *pSymbol = InternalGetSymbol(it->second);
+        if (pSymbol == nullptr)
+        {
+            return E_BOUNDS;
+        }
+
+        ComPtr<ISvcSymbol> spSymbol = pSymbol;
+        *ppSymbol = spSymbol.Detach();
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT SymbolSet::FindSymbolByOffset(_In_ ULONG64 moduleOffset,
+                                      _In_ bool exactMatchOnly,
+                                      _COM_Outptr_ ISvcSymbol **ppSymbol,
+                                      _Out_ ULONG64 *pSymbolOffset)
+{
+    HRESULT hr = S_OK;
+    *ppSymbol = nullptr;
+
+    SymbolRangeList::SymbolList const* pSymbols;
+    if (!m_symbolRanges.FindSymbols(moduleOffset, &pSymbols) || pSymbols->size() == 0)
+    {
+        return E_BOUNDS;
+    }
+
+    BaseSymbol *pSymbol = InternalGetSymbol((*pSymbols)[0]);
+
+    ULONG64 symbolOffset;
+    IfFailedReturn(pSymbol->GetOffset(&symbolOffset));
+
+    if (exactMatchOnly && symbolOffset != moduleOffset)
+    {
+        return E_BOUNDS;
+    }
+
+    ComPtr<ISvcSymbol> spSymbol = pSymbol;
+
+    *pSymbolOffset = (moduleOffset - symbolOffset);
+    *ppSymbol = spSymbol.Detach();
+    return S_OK;
+}
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger

--- a/TargetComposition/SymBuilder/SymbolSet.h
+++ b/TargetComposition/SymBuilder/SymbolSet.h
@@ -1,0 +1,479 @@
+//**************************************************************************
+//
+// SymbolSet.h
+//
+// The header for our implementation of a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMBOLSET_H__
+#define __SYMBOLSET_H__
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+//*************************************************
+// Overall Symbol Set:
+//
+
+// SymbolRangeList:
+//
+// Provides a list of address ranges in sorted order which can be binary searched for a given symbol or set
+// of symbols.
+//
+class SymbolRangeList
+{
+public:
+
+    using SymbolList = std::vector<ULONG64>;
+
+    // SymbolRangeList():
+    //
+    // Creates a new symbol range list covering the half-open set [start, end).  Initially, there
+    // are no symbols in the list.
+    //
+    SymbolRangeList()
+    {
+    }
+
+    // FindSymbols():
+    //
+    // Find the list of symbols which overlap a given address.  If such can be found, true is returned and
+    // an output pointer to the list of symbol ids is passed in 'pSymbolList'
+    //
+    bool FindSymbols(_In_ ULONG64 address, _Out_ SymbolList const** pSymbolList);
+
+    // AddSymbol():
+    //
+    // Adds a symbol to the range list.  The symbol's address range is given by the half-open set 
+    // [start, end).  
+    //
+    HRESULT AddSymbol(_In_ ULONG64 start, _In_ ULONG64 end, _In_ ULONG64 symbol);
+
+    // RemoveSymbol():
+    //
+    // Removes a symbol from the range list.
+    //
+    HRESULT RemoveSymbol(_In_ ULONG64 start, _In_ ULONG64 end, _In_ ULONG64 symbol);
+
+private:
+    
+    struct AddressRange
+    {
+        ULONG64 Start;
+        ULONG64 End;
+        SymbolList Symbols;
+    };
+
+    // RemoveSymbolFromList():
+    //
+    // Removes a symbol from the given list.
+    //
+    void RemoveSymbolFromList(_Inout_ SymbolList& list, _In_ ULONG64 symbol)
+    {
+        for (auto it = list.begin(); it != list.end(); ++it)
+        {
+            if (*it == symbol)
+            {
+                list.erase(it);
+                break;
+            }
+        }
+    }
+
+    std::vector<AddressRange> m_ranges;
+
+};
+
+// SymbolSet:
+//
+// Our representation for our "in memory constructed" symbols for a given module within a given 
+// process context.
+//
+class SymbolSet : 
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        ISvcSymbolSet,
+        ISvcSymbolSetSimpleNameResolution,
+        ISvcDescription
+        >
+{
+public:
+
+    SymbolSet() :
+        m_nextId(0),
+        m_demandCreatePointerTypes(true),
+        m_demandCreateArrayTypes(true)
+    {
+    }
+
+    //*************************************************
+    // ISvcSymbolSet:
+    //
+
+    //
+    // GetSymbolById():
+    //
+    // Returns the symbol for a given symbol ID (returned by ISvcSymbol::GetId)
+    //
+    IFACEMETHOD(GetSymbolById)(_In_ ULONG64 symbolId,
+                               _COM_Outptr_ ISvcSymbol **ppSymbol)
+    {
+        *ppSymbol = nullptr;
+        if (symbolId >= m_symbols.size())
+        {
+            return E_INVALIDARG;
+        }
+
+        Microsoft::WRL::ComPtr<ISvcSymbol> spSymbol = m_symbols[static_cast<size_t>(symbolId)];
+        *ppSymbol = spSymbol.Detach();
+        return S_OK;
+    }
+	
+    //
+    // EnumerateAllSymbols():
+    //
+    // Enumerates all symbols in the set.
+    //
+    IFACEMETHOD(EnumerateAllSymbols)(_COM_Outptr_ ISvcSymbolSetEnumerator **ppEnumerator);
+
+    //*************************************************
+    // ISvcSymbolSetSimpleNameResolution:
+    //
+
+    // FindSymbolByName():
+    //
+    // Finds symbolic information for a given name.  The method fails if the symbol cannot be located.
+    //
+    IFACEMETHOD(FindSymbolByName)(_In_ PCWSTR symbolName, _COM_Outptr_ ISvcSymbol **ppSymbol);
+
+    // FindSymbolByOffset():
+    //
+    // Finds symbolic information for a given offset.  If the "exactMatchOnly" parameter is true, this will only return
+    // a symbol which is exactly at the offset given.  If the "exactMatchOnly" parameter is false, this will return the 
+    // closest symbol before the given offset.  If no such symbol can be found, the method fails.
+    //
+    // Note that if a given symbol (e.g.: a function) has multiple disjoint address ranges and one of those address
+    // ranges has been moved to *BELOW* the base address of the symbol, the returned "symbolOffset" may be
+    // interpreted as a signed value (and S_FALSE should be returned in such a case).  This can be confirmed
+    // by querying the symbol for its address ranges.
+    //
+    IFACEMETHOD(FindSymbolByOffset)(_In_ ULONG64 moduleOffset,
+                                    _In_ bool exactMatchOnly,
+                                    _COM_Outptr_ ISvcSymbol **ppSymbol,
+                                    _Out_ ULONG64 *pSymbolOffset);
+
+    //*************************************************
+    // ISvcDescription:
+    //
+
+    // GetDescription():
+    //
+    // Gets a description of the object on which the interface exists.  This is intended for short textual
+    // display in some UI element.
+    //
+    IFACEMETHOD(GetDescription)(_Out_ BSTR *pObjectDescription)
+    {
+        //
+        // Give the symbol set a description so that commands in the debugger (e.g.: lm) can show something
+        // useful for what kind of symbols are loaded.
+        //
+        *pObjectDescription = SysAllocString(L"Symbol Builder Symbols");
+        return (*pObjectDescription == nullptr ? E_OUTOFMEMORY : S_OK);
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    // RuntimeClassInitialize():
+    //
+    // Initialize a new symbol set.
+    //
+    HRESULT RuntimeClassInitialize(_In_ ISvcModule *pModule, 
+                                   _In_ SymbolBuilderProcess *pOwningProcess,
+                                   _In_ bool addBasicCTypes = true)
+    {
+        HRESULT hr = S_OK;
+
+        m_spModule = pModule;
+        m_pOwningProcess = pOwningProcess;
+
+        if (addBasicCTypes)
+        {
+            hr = AddBasicCTypes();
+        }
+
+        return hr;
+    }
+
+    // AddBasicCTypes():
+    //
+    // Called to add a basic set of C defined types to the symbol set.
+    //
+    HRESULT AddBasicCTypes();
+
+    // AddNewSymbol():
+    //
+    // Called to add a new symbol to our management lists and assign it a unique id.
+    //
+    HRESULT AddNewSymbol(_In_ BaseSymbol *pBaseSymbol, _Out_ ULONG64 *pUniqueId);
+
+    // DeleteExistingSymbol():
+    //
+    // Called to delete a symbol from our management lists.  If anyone still has a handle to the unique id
+    // associated with that symbol, their symbol becomes invalid.  The symbol will no longer resolve.
+    //
+    HRESULT DeleteExistingSymbol(_In_ ULONG64 uniqueId);
+
+    // InvalidateExternalCaches():
+    //
+    // Fires an event notification to any listeners indicating that their caching of symbols from this
+    // set should be invalidated.  This is required *ANY TIME* we *CHANGE* the underlying types, fields, etc...
+    // that we project upwards.
+    //
+    HRESULT InvalidateExternalCaches();
+
+    // FindTypeByName():
+    //
+    // Finds a type by name.  If the symbol set is allowed to demand create pointer and array types and
+    // 'allowAutoCreations' is true, this will do so if need be.
+    //
+    HRESULT FindTypeByName(_In_ std::wstring const& typeName,
+                           _Out_ ULONG64 *pTypeId,
+                           _COM_Outptr_opt_ BaseTypeSymbol **ppTypeSymbol,
+                           _In_ bool allowAutoCreations = true);
+
+    //*************************************************
+    // Internal Accessors:
+    //
+
+    // InternalGetSymbol():
+    //
+    // Gets a symbol by its unique ID without adding any reference count.  The caller must be extremely
+    // careful in its usage of this symbol.
+    //
+    BaseSymbol *InternalGetSymbol(_In_ ULONG64 uniqueId) const
+    {
+        if (uniqueId >= m_symbols.size())
+        {
+            return nullptr;
+        }
+
+        ISvcSymbol *pSymbol = m_symbols[static_cast<size_t>(uniqueId)].Get();
+        return static_cast<BaseSymbol *>(pSymbol);
+    }
+
+    // InternalGetSymbolByName():
+    //
+    // Finds a symbol by its fully qualified name.  Returns 0 as a symbol id if no such symbol can be found.
+    //
+    ULONG64 InternalGetSymbolIdByName(_In_ std::wstring const& symbolName)
+    {
+        auto it = m_symbolNameMap.find(symbolName);
+        if (it == m_symbolNameMap.end())
+        {
+            return 0;
+        }
+        return it->second;
+    }
+
+    // InternalAddSymbolRange():
+    //
+    // Adds a mapping of [start, end) as a half-open address range to the existing symbol.
+    //
+    HRESULT InternalAddSymbolRange(_In_ ULONG64 start, _In_ ULONG64 end, _In_ ULONG64 symbol)
+    {
+        return m_symbolRanges.AddSymbol(start, end, symbol);
+    }
+
+    // InternalRemoveSymbolRange():
+    //
+    // Removes a mapping of [start, end) as a half-open address range from the existing symbol.
+    //
+    HRESULT InternalRemoveSymbolRange(_In_ ULONG64 start, _In_ ULONG64 end, _In_ ULONG64 symbol)
+    {
+        return m_symbolRanges.RemoveSymbol(start, end, symbol);
+    }
+
+    std::vector<Microsoft::WRL::ComPtr<ISvcSymbol>> const& InternalGetSymbols() { return m_symbols; }
+    std::vector<ULONG64> const& InternalGetGlobalSymbols() const { return m_globalSymbols; }
+    IDebugServiceManager* GetServiceManager() const;
+    ISvcMachineArchitecture* GetArchInfo() const;
+
+private:
+
+    ULONG64 GetUniqueId() 
+    {
+        return ++m_nextId;
+    }
+
+    // The next "unique id" that we will hand out when a new symbol is constructed
+    ULONG64 m_nextId;
+
+    // The master index of all symbols by their assigned unique id.
+    std::vector<Microsoft::WRL::ComPtr<ISvcSymbol>> m_symbols;
+
+    // The master index of "global" symbols
+    std::vector<ULONG64> m_globalSymbols;
+
+    // The master index of names -> global symbol IDs
+    std::unordered_map<std::wstring, ULONG64> m_symbolNameMap;
+
+    // The module for which we are the symbols
+    Microsoft::WRL::ComPtr<ISvcModule> m_spModule;
+
+    // Weak pointer back 
+    SymbolBuilderProcess *m_pOwningProcess;
+
+    // Tracks the address ranges associated with global symbols.
+    SymbolRangeList m_symbolRanges;
+
+    // Configuration options:
+    bool m_demandCreatePointerTypes;
+    bool m_demandCreateArrayTypes;
+    
+};
+
+// GlobalSymbolEnumerator:
+//
+// An enumerator which enumerates all of the global symbols within a symbol set.
+//
+class GlobalEnumerator :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        ISvcSymbolSetEnumerator
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolSetEnumerator:
+    //
+
+    // Reset():
+    //
+    // Resets the position of the enumerator.
+    //
+    IFACEMETHOD(Reset)()
+    {
+        m_pos = 0;
+        return S_OK;
+    }
+
+    // GetNext():
+    //
+    // Gets the next symbol from the enumerator.
+    //
+    IFACEMETHOD(GetNext)(_COM_Outptr_ ISvcSymbol **ppSymbol)
+    {
+        *ppSymbol = nullptr;
+
+        //
+        // NOTE: There may be gaps in our id <-> symbol mapping because of deleted symbols or other
+        //       unused IDs.  We cannot return nullptr.  Any such empty slot in our internal list
+        //       needs to be skipped.
+        //
+        auto&& symbols = m_spSymbolSet->InternalGetSymbols();
+
+        while (m_pos < symbols.size())
+        {
+            Microsoft::WRL::ComPtr<ISvcSymbol> spSymbol = symbols[m_pos];
+            ++m_pos;
+            if (spSymbol.Get() != nullptr)
+            {
+                *ppSymbol = spSymbol.Detach();
+                return S_OK;
+            }
+        }
+
+        return E_BOUNDS;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet)
+    {
+        m_spSymbolSet = pSymbolSet;
+        return Reset();
+    }
+
+private:
+
+    size_t m_pos;
+    Microsoft::WRL::ComPtr<SymbolSet> m_spSymbolSet;
+
+};
+
+// SymbolCacheInvalidateArguments:
+//
+// An event arguments class for DEBUG_SVCEVENT_SYMBOLCACHEINVALIDATE.
+//
+class SymbolCacheInvalidateArguments :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        ISvcEventArgumentsSymbolCacheInvalidate
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcEventArgumentsSymbolCacheInvalidate:
+    //
+
+    // GetSymbolsInformation():
+    //
+    // Gets information about the module and symbol set for which cache invalidation should occur.
+    //
+    IFACEMETHOD(GetSymbolsInformation)(_COM_Outptr_ ISvcModule **ppModule,
+                                       _COM_Outptr_ ISvcSymbolSet **ppSymbolSet)
+    {
+        Microsoft::WRL::ComPtr<ISvcModule> spModule = m_spModule;
+        Microsoft::WRL::ComPtr<ISvcSymbolSet> spSymbolSet = m_spSymbolSet;
+
+        *ppModule = spModule.Detach();
+        *ppSymbolSet = spSymbolSet.Detach();
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ ISvcModule *pModule,
+                                   _In_ ISvcSymbolSet *pSymbolSet)
+    {
+        m_spModule = pModule;
+        m_spSymbolSet = pSymbolSet;
+        return S_OK;
+    }
+
+
+private:
+
+    Microsoft::WRL::ComPtr<ISvcModule> m_spModule;
+    Microsoft::WRL::ComPtr<ISvcSymbolSet> m_spSymbolSet;
+};
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger
+
+
+#endif // __SYMBOLSET_H__

--- a/TargetComposition/SymBuilder/SymbolTypes.cpp
+++ b/TargetComposition/SymBuilder/SymbolTypes.cpp
@@ -1,0 +1,646 @@
+//**************************************************************************
+//
+// SymbolTypes.cpp
+//
+// The implementation of types within a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#include "SymBuilder.h"
+
+using namespace Microsoft::WRL;
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+//*************************************************
+// UDT Positional Symbols (Fields / Base Classes / Etc...)
+//
+
+HRESULT UdtPositionalSymbol::BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                                            _In_ SvcSymbolKind symKind,
+                                            _In_ ULONG64 owningTypeId,
+                                            _In_ ULONG64 symOffset,
+                                            _In_ ULONG64 symTypeId,
+                                            _In_opt_ PCWSTR pwszName)
+{
+    //
+    // The base data symbol doesn't have a distinction between offset and actual offset.  Only we do.  Mark
+    // the actual offset the same as the offset.  Any triggering of type layout will change this if such
+    // is marked as automatic.
+    //
+    m_symOffsetActual = m_symOffset;
+    return BaseDataSymbol::BaseInitialize(pSymbolSet, symKind, owningTypeId, symOffset, symTypeId, pwszName, nullptr);
+}
+
+HRESULT UdtPositionalSymbol::BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                                            _In_ ULONG64 owningTypeId,
+                                            _In_ VARIANT *pValue,
+                                            _In_ ULONG64 symTypeId,
+                                            _In_ PCWSTR pwszName)
+{
+    //
+    // The base data symbol doesn't have a distinction between offset and actual offset.  Only we do.  Mark
+    // the actual offset the same as the offset.  Any triggering of type layout will change this if such
+    // is marked as automatic.
+    //
+    m_symOffsetActual = m_symOffset;
+    return BaseDataSymbol::BaseInitialize(pSymbolSet, SvcSymbolField, owningTypeId, pValue, symTypeId, pwszName, nullptr);
+}
+
+HRESULT UdtPositionalSymbol::MoveToBefore(_In_ ULONG64 position)
+{
+    BaseSymbol *pParentSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_parentId);
+    if (pParentSymbol == nullptr)
+    {
+        return E_UNEXPECTED;
+    }
+
+    return pParentSymbol->MoveChildBefore(InternalGetId(), position, InternalGetKind());
+}
+
+//*************************************************
+// UDT Symbols:
+//
+
+HRESULT UdtTypeSymbol::LayoutType()
+{
+    ULONG64 typeSize = 0; 
+    ULONG64 curOffset = 0;
+    ULONG64 maxAlignment = 1;
+
+    SvcSymbolKind passKinds[] = { SvcSymbolBaseClass, SvcSymbolField };
+
+    //
+    // Walk through all our children (mostly looking at fields) and figure out where each field goes
+    // in the layout given alignment, packing, and sizes.
+    //
+    // We need to make this pass several times because things like base classes must come *BEFORE* fields
+    // and the like.
+    //
+    auto&& children = InternalGetChildren();
+    for (size_t pass = 0; pass < ARRAYSIZE(passKinds); ++pass)
+    {
+        SvcSymbolKind passKind = passKinds[pass];
+
+        for (size_t i = 0; i < children.size(); ++i)
+        {
+            BaseSymbol *pBaseSymbol = InternalGetSymbolSet()->InternalGetSymbol(children[i]);
+            if (pBaseSymbol == nullptr)
+            {
+                return E_UNEXPECTED;
+            }
+
+            if (pBaseSymbol->InternalGetKind() != passKind)
+            {
+                continue;
+            }
+
+            UdtPositionalSymbol *pPosSymbol = static_cast<UdtPositionalSymbol *>(pBaseSymbol);
+
+            //
+            // Find the type of the field and gather basic information about size/alignment to see
+            // if we need to add requisite padding (assuming this is an auto-layout field).  If the field offset
+            // was manually specified, it goes there REGARDLESS of what the alignment says.
+            //
+            ULONG64 symTypeId = pPosSymbol->InternalGetSymbolTypeId();
+            BaseSymbol *pSymbolTypeBaseSymbol = InternalGetSymbolSet()->InternalGetSymbol(symTypeId);
+            if (pSymbolTypeBaseSymbol == nullptr || pSymbolTypeBaseSymbol->InternalGetKind() != SvcSymbolType)
+            {
+                return E_UNEXPECTED;
+            }
+
+            BaseTypeSymbol *pSymbolTypeBase = static_cast<BaseTypeSymbol *>(pSymbolTypeBaseSymbol);
+
+            ULONG64 symTypeSize = pSymbolTypeBase->InternalGetTypeSize();
+            ULONG64 symTypeAlign = pSymbolTypeBase->InternalGetTypeAlignment();
+
+            if (symTypeAlign > maxAlignment)
+            {
+                maxAlignment = symTypeAlign;
+            }
+
+            ULONG64 symOffset = pPosSymbol->InternalGetSymbolOffset();
+            bool autoLayoutField = (symOffset == UdtPositionalSymbol::AutomaticAppendLayout);
+
+            if (autoLayoutField)
+            {
+                symOffset = curOffset;
+                if (symTypeAlign != 1)
+                {
+                    symOffset = ((symOffset + (symTypeAlign - 1)) / symTypeAlign) * symTypeAlign;
+                }
+                pPosSymbol->InternalSetComputedSymbolOffset(symOffset);
+            }
+
+            curOffset = symOffset + symTypeSize;
+            if (typeSize < curOffset)
+            {
+                typeSize = curOffset;
+            }
+        }
+    }
+
+    m_typeAlignment = maxAlignment;
+    if (maxAlignment != 1)
+    {
+        typeSize = ((typeSize + (maxAlignment - 1)) / maxAlignment) * maxAlignment;
+    }
+    m_typeSize = typeSize;
+
+    return S_OK;
+}
+
+//*************************************************
+// Pointer Symbols:
+//
+
+HRESULT PointerTypeSymbol::GetBaseType(_Out_ ISvcSymbol **ppBaseType)
+{
+    HRESULT hr = S_OK;
+    *ppBaseType = nullptr;
+
+    BaseSymbol *pPointerToSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_pointerToId);
+    if (pPointerToSymbol == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    ComPtr<ISvcSymbol> spPointerToSymbol = pPointerToSymbol;
+    *ppBaseType = spPointerToSymbol.Detach();
+    return hr;
+}
+
+HRESULT PointerTypeSymbol::RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                                  _In_ ULONG64 pointerToId,
+                                                  _In_ SvcSymbolPointerKind pointerKind)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        HRESULT hr = S_OK;
+
+        ISvcMachineArchitecture *pArchInfo = pSymbolSet->GetArchInfo();
+        if (pArchInfo == nullptr)
+        {
+            return E_UNEXPECTED;
+        }
+
+        BaseSymbol *pPointerToSymbol = pSymbolSet->InternalGetSymbol(pointerToId);
+        if (pPointerToSymbol == nullptr || pPointerToSymbol->InternalGetKind() != SvcSymbolType)
+        {
+            return E_INVALIDARG;
+        }
+
+        std::wstring const& name = pPointerToSymbol->InternalGetName();
+        std::wstring const& qualifiedName = pPointerToSymbol->InternalGetQualifiedName();
+
+        std::wstring ptrName;
+        std::wstring ptrQualifiedName;
+
+        if (!name.empty())
+        {
+            ptrName = name;
+            AppendPtrChar(ptrName, pointerKind);
+        }
+
+        if (!qualifiedName.empty())
+        {
+            ptrQualifiedName = qualifiedName;
+            AppendPtrChar(ptrQualifiedName, pointerKind);
+        }
+
+        IfFailedReturn(BaseTypeSymbol::BaseInitialize(pSymbolSet, 
+                                                      SvcSymbolType, 
+                                                      SvcSymbolTypePointer,
+                                                      0,
+                                                      ptrName.empty() ? nullptr : ptrName.c_str(),
+                                                      ptrQualifiedName.empty() ? nullptr : ptrQualifiedName.c_str()));
+
+        m_pointerKind = pointerKind;
+        m_pointerToId = pointerToId;
+        
+        m_typeSize = pArchInfo->GetBitness() / 8;
+        m_typeAlignment = pArchInfo->GetBitness() / 8;
+
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+//*************************************************
+// Array Symbols:
+//
+
+HRESULT ArrayTypeSymbol::GetBaseType(_Out_ ISvcSymbol **ppBaseType)
+{
+    HRESULT hr = S_OK;
+    *ppBaseType = nullptr;
+
+    BaseSymbol *pArrayOfSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_arrayOfTypeId);
+    if (pArrayOfSymbol == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    ComPtr<ISvcSymbol> spArrayOfSymbol = pArrayOfSymbol;
+    *ppBaseType = spArrayOfSymbol.Detach();
+    return hr;
+}
+
+HRESULT ArrayTypeSymbol::GetArrayDimensions(_In_ ULONG64 dimensions,
+                                            _Out_writes_(dimensions) SvcSymbolArrayDimension *pDimensions)
+{
+    if (dimensions != 1)
+    {
+        return E_INVALIDARG;
+    }
+
+    pDimensions[0].DimensionFlags = 0;
+    pDimensions[0].LowerBound = 0;
+    pDimensions[0].Length = m_arrayDim;
+    pDimensions[0].Stride = m_baseTypeSize;
+    return S_OK;
+}
+
+HRESULT ArrayTypeSymbol::RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                                _In_ ULONG64 arrayOfId,
+                                                _In_ ULONG64 arrayDim)
+{
+    //
+    // We cannot let a C++ exception escape.
+    //
+    auto fn = [&]()
+    {
+        HRESULT hr = S_OK;
+
+        wchar_t arBuf[64];
+        swprintf_s(arBuf, ARRAYSIZE(arBuf), L"[%I64d]", arrayDim);
+
+        BaseSymbol *pArrayOfSymbol = pSymbolSet->InternalGetSymbol(arrayOfId);
+        if (pArrayOfSymbol == nullptr || pArrayOfSymbol->InternalGetKind() != SvcSymbolType)
+        {
+            return E_INVALIDARG;
+        }
+
+        BaseTypeSymbol *pArrayOfType = static_cast<BaseTypeSymbol *>(pArrayOfSymbol);
+        ULONG64 arrayOfTypeSize = pArrayOfType->InternalGetTypeSize();
+        ULONG64 arrayOfTypeAlign = pArrayOfType->InternalGetTypeAlignment();
+
+        std::wstring const& name = pArrayOfSymbol->InternalGetName();
+        std::wstring const& qualifiedName = pArrayOfSymbol->InternalGetQualifiedName();
+
+        std::wstring arrayName;
+        std::wstring arrayQualifiedName;
+
+        if (!name.empty())
+        {
+            arrayName = name;
+            arrayName += arBuf;
+        }
+
+        if (!qualifiedName.empty())
+        {
+            arrayQualifiedName = qualifiedName;
+            arrayQualifiedName += arBuf;
+        }
+
+        IfFailedReturn(BaseTypeSymbol::BaseInitialize(pSymbolSet, 
+                                                      SvcSymbolType, 
+                                                      SvcSymbolTypeArray,
+                                                      0,
+                                                      arrayName.empty() ? nullptr : arrayName.c_str(),
+                                                      arrayQualifiedName.empty() ? nullptr : arrayQualifiedName.c_str()));
+
+        m_arrayDim = arrayDim;
+        m_arrayOfTypeId = arrayOfId;
+        m_baseTypeSize = arrayOfTypeSize;
+        
+        m_typeSize = (m_baseTypeSize * m_arrayDim);
+        m_typeAlignment = arrayOfTypeAlign;
+
+        //
+        // Add a dependency notification between the type of this array and us owning type.  That way,
+        // if the layout of the underlying type changes, we can recompute our own layout (and do this all the way
+        // up any dependency tree).
+        //
+        IfFailedReturn(pArrayOfType->AddDependentNotify(InternalGetId()));
+
+        return S_OK;
+    };
+    return ConvertException(fn);
+}
+
+HRESULT ArrayTypeSymbol::NotifyDependentChange()
+{
+    BaseSymbol *pArrayOfSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_arrayOfTypeId);
+    if (pArrayOfSymbol == nullptr || pArrayOfSymbol->InternalGetKind() != SvcSymbolType)
+    {
+        return E_INVALIDARG;
+    }
+
+    BaseTypeSymbol *pArrayOfType = static_cast<BaseTypeSymbol *>(pArrayOfSymbol);
+
+    m_baseTypeSize = pArrayOfType->InternalGetTypeSize();
+    m_typeAlignment = pArrayOfType->InternalGetTypeAlignment();
+    m_typeSize = (m_baseTypeSize * m_arrayDim);
+
+    return BaseSymbol::NotifyDependentChange();
+}
+
+HRESULT ArrayTypeSymbol::Delete()
+{
+    HRESULT hr = S_OK;
+
+    BaseSymbol *pArrayOfType = InternalGetSymbolSet()->InternalGetSymbol(m_arrayOfTypeId);
+    if (pArrayOfType != nullptr)
+    {
+        //
+        // Remove a dependency notification between the type of this array and us.  We are going away and no
+        // longer need the notification.
+        //
+        IfFailedReturn(pArrayOfType->RemoveDependentNotify(InternalGetId()));
+    }
+
+    return BaseSymbol::Delete();
+}
+
+//*************************************************
+// Typedef Symbols:
+//
+
+HRESULT TypedefTypeSymbol::GetBaseType(_Out_ ISvcSymbol **ppBaseType)
+{
+    HRESULT hr = S_OK;
+    *ppBaseType = nullptr;
+
+    BaseSymbol *pTypedefOfSymbol = InternalGetSymbolSet()->InternalGetSymbol(m_typedefOfTypeId);
+    if (pTypedefOfSymbol == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    ComPtr<ISvcSymbol> spTypedefOfSymbol = pTypedefOfSymbol;
+    *ppBaseType = spTypedefOfSymbol.Detach();
+    return hr;
+}
+
+HRESULT TypedefTypeSymbol::RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                                  _In_ ULONG64 typedefOfId,
+                                                  _In_ ULONG64 parentId,
+                                                  _In_ PCWSTR pwszName,
+                                                  _In_opt_ PCWSTR pwszQualifiedName)
+{
+    HRESULT hr = S_OK;
+
+    BaseSymbol *pTypedefOfSymbol = pSymbolSet->InternalGetSymbol(typedefOfId);
+    if (pTypedefOfSymbol == nullptr || pTypedefOfSymbol->InternalGetKind() != SvcSymbolType)
+    {
+        return E_INVALIDARG;
+    }
+
+    BaseTypeSymbol *pTypedefOfType = static_cast<BaseTypeSymbol *>(pTypedefOfSymbol);
+
+    IfFailedReturn(BaseTypeSymbol::BaseInitialize(pSymbolSet, 
+                                                  SvcSymbolType, 
+                                                  SvcSymbolTypeTypedef,
+                                                  parentId,
+                                                  pwszName,
+                                                  pwszQualifiedName));
+
+    m_typedefOfTypeId = typedefOfId;
+
+    m_typeSize = pTypedefOfType->InternalGetTypeSize();
+    m_typeAlignment = pTypedefOfType->InternalGetTypeAlignment();
+    return hr;
+}
+
+//*************************************************
+// Enum Symbols:
+//
+
+HRESULT EnumTypeSymbol::GetBaseType(_Out_ ISvcSymbol **ppBaseType)
+{
+    HRESULT hr = S_OK;
+    *ppBaseType = nullptr;
+
+    BaseSymbol *pEnumBaseType = InternalGetSymbolSet()->InternalGetSymbol(m_enumBasicTypeId);
+    if (pEnumBaseType == nullptr)
+    {
+        return E_FAIL;
+    }
+
+    ComPtr<ISvcSymbol> spEnumBaseType = pEnumBaseType;
+    *ppBaseType = spEnumBaseType.Detach();
+    return hr;
+}
+
+HRESULT EnumTypeSymbol::RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                               _In_ ULONG64 enumBasicTypeId,
+                                               _In_ ULONG64 parentId,
+                                               _In_ PCWSTR pwszName,
+                                               _In_opt_ PCWSTR pwszQualifiedName)
+{
+    HRESULT hr = S_OK;
+
+    //
+    // The base type of the enum *MUST* be a basic type which is ordinal.  Validate this.
+    //
+    BaseSymbol *pEnumBasicTypeSymbol = pSymbolSet->InternalGetSymbol(enumBasicTypeId);
+    if (pEnumBasicTypeSymbol == nullptr || pEnumBasicTypeSymbol->InternalGetKind() != SvcSymbolType)
+    {
+        return E_INVALIDARG;
+    }
+
+    BaseTypeSymbol *pEnumType = static_cast<BaseTypeSymbol *>(pEnumBasicTypeSymbol);
+    if (pEnumType->InternalGetTypeKind() != SvcSymbolTypeIntrinsic)
+    {
+        return E_INVALIDARG;
+    }
+
+    //
+    // Keep track of how values for this enum must pack based on the underlying basic type.
+    //
+    VARTYPE enumPacking = VT_EMPTY;
+    bool isSigned = false;
+
+    BasicTypeSymbol *pEnumBasicType = static_cast<BasicTypeSymbol *>(pEnumType);
+    m_enumIntrinsicKind = pEnumBasicType->InternalGetIntrinsicKind();
+    switch(m_enumIntrinsicKind)
+    {
+        case SvcSymbolIntrinsicBool:
+        {
+            enumPacking = VT_BOOL;
+            break;
+        }
+
+        case SvcSymbolIntrinsicChar:
+        case SvcSymbolIntrinsicInt:
+        case SvcSymbolIntrinsicLong:
+        {
+            isSigned = true;
+            break;
+        }
+
+        case SvcSymbolIntrinsicWChar:
+        case SvcSymbolIntrinsicUInt:
+        case SvcSymbolIntrinsicULong:
+        {
+            isSigned = false;
+            break;
+        }
+
+        default:
+            return E_INVALIDARG;
+    }
+
+    //
+    // If we haven't figured out a packing, it's a default ordinal and go with that path based on
+    // the underlying size of the type.
+    //
+    if (enumPacking == VT_EMPTY)
+    {
+        switch(pEnumBasicType->InternalGetTypeSize())
+        {
+            case 1:
+                enumPacking = (VARTYPE)(isSigned ? VT_I1 : VT_UI1);
+                break;
+            
+            case 2:
+                enumPacking = (VARTYPE)(isSigned ? VT_I2 : VT_UI2);
+                break;
+
+            case 4:
+                enumPacking = (VARTYPE)(isSigned ? VT_I4 : VT_UI4);
+                break;
+
+            case 8:
+                enumPacking = (VARTYPE)(isSigned ? VT_I8 : VT_UI8);
+                break;
+
+            default:
+                return E_INVALIDARG;
+        }
+    }
+
+    IfFailedReturn(BaseTypeSymbol::BaseInitialize(pSymbolSet, 
+                                                  SvcSymbolType, 
+                                                  SvcSymbolTypeEnum,
+                                                  parentId,
+                                                  pwszName,
+                                                  pwszQualifiedName));
+
+    m_enumBasicTypeId = enumBasicTypeId;
+    m_enumPacking = enumPacking;
+
+    m_typeSize = pEnumType->InternalGetTypeSize();
+    m_typeAlignment = pEnumType->InternalGetTypeAlignment();
+
+    return hr;
+}
+
+HRESULT EnumTypeSymbol::LayoutEnum()
+{
+    VARIANT vtVal;
+
+    memset(&vtVal, 0, sizeof(vtVal));
+    vtVal.vt = m_enumPacking;
+
+    //
+    // Walk through all our children (looking at enumerants) and figure out the actual values for any enumerant
+    // which is an "automatic increase" over the previous enumerant.
+    //
+    auto&& children = InternalGetChildren();
+    bool foundFirst = false;
+    for (size_t i = 0; i < children.size(); ++i)
+    {
+        BaseSymbol *pBaseSymbol = InternalGetSymbolSet()->InternalGetSymbol(children[i]);
+        if (pBaseSymbol == nullptr)
+        {
+            return E_UNEXPECTED;
+        }
+
+        if (pBaseSymbol->InternalGetKind() != SvcSymbolField)
+        {
+            continue;
+        }
+
+        UdtPositionalSymbol *pPosSymbol = static_cast<UdtPositionalSymbol *>(pBaseSymbol);
+
+        if (pPosSymbol->InternalIsConstantValue())
+        {
+            if (pPosSymbol->InternalIsIncreasingConstant())
+            {
+                if (foundFirst)
+                {
+                    switch(vtVal.vt)
+                    {
+                        case VT_I1:
+                            vtVal.cVal++;
+                            break;
+                        case VT_I2:
+                            vtVal.iVal++;
+                            break;
+                        case VT_I4:
+                            vtVal.lVal++;
+                            break;
+                        case VT_I8:
+                            vtVal.llVal++;
+                            break;
+                        case VT_UI1:
+                            vtVal.bVal++;
+                            break;
+                        case VT_UI2:
+                            vtVal.uiVal++;
+                            break;
+                        case VT_UI4:
+                            vtVal.ulVal++;
+                            break;
+                        case VT_UI8:
+                            vtVal.ullVal++;
+                            break;
+                        case VT_BOOL:
+                            if (vtVal.boolVal == VARIANT_FALSE)
+                            {
+                                vtVal.boolVal = VARIANT_TRUE;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                pPosSymbol->InternalSetComputedValue(vtVal);
+            }
+            else
+            {
+                vtVal = pPosSymbol->InternalGetSymbolValue();
+            }
+
+            foundFirst = true;
+        }
+    }
+
+    return S_OK;
+}
+
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger

--- a/TargetComposition/SymBuilder/SymbolTypes.h
+++ b/TargetComposition/SymBuilder/SymbolTypes.h
@@ -1,0 +1,934 @@
+//**************************************************************************
+//
+// SymbolTypes.h
+//
+// The header for our implementation of types within a "symbol set".  A "symbol set" is an
+// abstraction for the available symbols for a given module.  It is a set of
+// "stacked" interfaces which implements progressively more functionality depending
+// on the complexity of the symbol implementation.
+//
+//**************************************************************************
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//**************************************************************************
+
+#ifndef __SYMBOLTYPES_H__
+#define __SYMBOLTYPES_H__
+
+namespace Debugger
+{
+namespace TargetComposition
+{
+namespace Services
+{
+namespace SymbolBuilder
+{
+
+// BaseTypeSymbol:
+//
+// Our base class for all type symbols
+//
+class BaseTypeSymbol : 
+    public Microsoft::WRL::Implements<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseSymbol,
+        ISvcSymbolType
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolType:
+    //
+
+    // GetTypeKind():
+    //
+    // Gets the kind of type symbol that this is (e.g.: base type, struct, array, etc...)
+    //
+    IFACEMETHOD(GetTypeKind)(_Out_ SvcSymbolTypeKind *pTypeKind)
+    {
+        *pTypeKind = m_typeKind;
+        return S_OK;
+    }
+
+    // GetSize():
+    //
+    // Gets the overall size of the type as laid out in memory.
+    //
+    IFACEMETHOD(GetSize)(_Out_ ULONG64 *pSize)
+    {
+        *pSize = m_typeSize;
+        return S_OK;
+    }
+
+    // GetBaseType():
+    //
+    // If the type is a derivation of another single type (e.g.: as "MyStruct *" is derived from "MyStruct"),
+    // this returns the base type of the derivation.  For pointers, this would return the type pointed to.
+    // For arrays, this would return what the array is an array of.  If the type is not such a derivative
+    // type, an error is returned.
+    //
+    // Note that this method has nothing to do with C++ base classes.  Such are symbols which can be enumerated
+    // from the derived class.
+    //
+    IFACEMETHOD(GetBaseType)(_Out_ ISvcSymbol **ppBaseType)
+    {
+        //
+        // By default, we have no "base type."  A derived class may need to override this.
+        //
+        *ppBaseType = nullptr;
+        return E_NOTIMPL;
+    }
+
+    // GetUnmodifiedType():
+    //
+    // If the type is a qualified form (const/volatile/etc...) of another type, this returns a type symbol
+    // with all qualifiers stripped.
+    //
+    IFACEMETHOD(GetUnmodifiedType)(_Out_ ISvcSymbol **ppUnmodifiedType)
+    {
+        //
+        // By default, we have no "unmodified type."  A derived class may need to override this.
+        //
+        *ppUnmodifiedType = nullptr;
+        return E_NOTIMPL;
+    }
+
+    // GetIntrinsicType():
+    //
+    // If the type kind as reported by GetTypeKind is an intrinsic, this returns more information about
+    // the particular kind of intrinsic.
+    //
+    IFACEMETHOD(GetIntrinsicType)(_Out_opt_ SvcSymbolIntrinsicKind * /*pKind*/,
+                                  _Out_opt_ ULONG * /*pPackingSize*/)
+    {
+        //
+        // By default, we have no "intrinsic type" information.  A derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetPointerKind():
+    //
+    // Returns what kind of pointer the type is (e.g.: a standard pointer, a pointer to member,
+    // a reference, an r-value reference, etc...
+    //
+    IFACEMETHOD(GetPointerKind)(_Out_ SvcSymbolPointerKind * /*pKind*/)
+    {
+        //
+        // By default, we have no "pointer kind."  A derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetMemberType():
+    //
+    // If the pointer is a pointer-to-class-member, this returns the type of such class.
+    //
+    IFACEMETHOD(GetMemberType)(_COM_Outptr_ ISvcSymbolType **ppMemberType)
+    {
+        //
+        // By default, we have no "member type."  A derived class may need to override this.
+        //
+        *ppMemberType = nullptr;
+        return E_NOTIMPL;
+    }
+
+    // GetArrayDimensionality():
+    //
+    // Returns the dimensionality of the array.  There is no guarantee that every array type representable by
+    // these interfaces is a standard zero-based one dimensional array as is standard in C.
+    //
+    IFACEMETHOD(GetArrayDimensionality)(_Out_ ULONG64 * /*pArrayDimensionality*/)
+    {
+        //
+        // By default, we have no "array dimensionality."  A derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetArrayDimensions():
+    //
+    // Fills in information about each dimension of the array including its lower bound, length, and
+    // stride.
+    //
+    IFACEMETHOD(GetArrayDimensions)(_In_ ULONG64 dimensions,
+                                    _Out_writes_(dimensions) SvcSymbolArrayDimension * /*pDimensions*/)
+    {
+        //
+        // By default, we have no "array dimensions."  A derived class may need to override this.
+        //
+        UNREFERENCED_PARAMETER(dimensions);
+        return E_NOTIMPL;
+    }
+
+    // GetArrayHeaderSize():
+    //
+    // Gets the size of any header of the array (this is the offset of the first element of the array as
+    // described by the dimensions).
+    //
+    // This should *ALWAYS* return 0 for a C style array.
+    //
+    IFACEMETHOD(GetArrayHeaderSize)(_Out_ ULONG64 * /*pArrayHeaderSize*/)
+    {
+        //
+        // By default, we have no "array header size."  A derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetFunctionReturnType():
+    //
+    // Returns the return type of a function.  Even non-value returning functions (e.g.: void) should return
+    // a type representing this.
+    //
+    IFACEMETHOD(GetFunctionReturnType)(_COM_Outptr_ ISvcSymbol **ppReturnType)
+    {
+        //
+        // By default, we have no "function return type."  A derived class may need to override this.
+        //
+        *ppReturnType = nullptr;
+        return E_NOTIMPL;
+    }
+
+    // GetFunctionParameterTypeCount():
+    //
+    // Returns the number of parameters that the function takes.
+    //
+    IFACEMETHOD(GetFunctionParameterTypeCount)(_Out_ ULONG64 * /*pCount*/)
+    {
+        //
+        // By default, we have no "function parameter type count."  A derived class may need to override this.
+        //
+        return E_NOTIMPL;
+    }
+
+    // GetFunctionParameterTypeAt():
+    //
+    // Returns the type of the "i"-th argument to the function as a new ISvcSymbol
+    //
+    IFACEMETHOD(GetFunctionParameterTypeAt)(_In_ ULONG64 /*i*/,
+                                            _COM_Outptr_ ISvcSymbol **ppParameterType)
+    {
+        //
+        // By default, we have no "function parameter types."  A derived class may need to override this.
+        //
+        *ppParameterType = nullptr;
+        return E_NOTIMPL;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                           _In_ SvcSymbolKind kind,
+                           _In_ SvcSymbolTypeKind typeKind,
+                           _In_ ULONG64 parentId,
+                           _In_opt_ PCWSTR pwszSymbolName = nullptr,
+                           _In_opt_ PCWSTR pwszQualifiedName = nullptr)
+    {
+        HRESULT hr = S_OK;
+        IfFailedReturn(BaseSymbol::BaseInitialize(pSymbolSet, kind, parentId, pwszSymbolName, pwszQualifiedName));
+        m_typeKind = typeKind;
+        m_typeSize = 0;
+        m_typeAlignment = 1;
+        return hr;
+    }
+
+    //*************************************************
+    // Internal Accessors():
+    //
+
+    SvcSymbolTypeKind InternalGetTypeKind() const { return m_typeKind; }
+    ULONG64 InternalGetTypeSize() const { return m_typeSize; }
+    ULONG64 InternalGetTypeAlignment() const { return m_typeAlignment; }
+
+protected:
+
+    SvcSymbolTypeKind m_typeKind;
+    ULONG64 m_typeSize;
+    ULONG64 m_typeAlignment;
+};
+
+// BasicTypeSymbol:
+//
+// A type symbol which represents some basic type (e.g.: int, float, etc...)
+//
+class BasicTypeSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseTypeSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolType:
+    //
+
+    // GetIntrinsicType():
+    //
+    // If the type kind as reported by GetTypeKind is an intrinsic, this returns more information about
+    // the particular kind of intrinsic.
+    //
+    IFACEMETHOD(GetIntrinsicType)(_Out_opt_ SvcSymbolIntrinsicKind *pKind,
+                                  _Out_opt_ ULONG *pPackingSize)
+    {
+        if (pKind != nullptr)
+        {
+            *pKind = m_intrinsicKind;
+        }
+        if (pPackingSize != nullptr)
+        {
+            *pPackingSize = static_cast<ULONG>(m_typeSize);
+        }
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ SvcSymbolIntrinsicKind intrinsicKind,
+                                   _In_ ULONG packingSize,
+                                   _In_ PCWSTR pwszName)
+    {
+        HRESULT hr = S_OK;
+        IfFailedReturn(BaseInitialize(pSymbolSet, SvcSymbolType, SvcSymbolTypeIntrinsic, 0, pwszName));
+        m_intrinsicKind = intrinsicKind;
+        m_typeSize = packingSize;
+        m_typeAlignment = packingSize;
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal Accessors:
+    //
+
+    SvcSymbolIntrinsicKind InternalGetIntrinsicKind() const { return m_intrinsicKind; }
+
+private:
+
+    SvcSymbolIntrinsicKind m_intrinsicKind;
+
+};
+
+// UdtTypeSymbol:
+//
+// A type symbol which represents some user defined type (e.g.: struct, class, etc...)
+//
+class UdtTypeSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseTypeSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    virtual HRESULT NotifyDependentChange()
+    {
+        HRESULT hr = LayoutType();
+        if (SUCCEEDED(hr))
+        {
+            hr = BaseSymbol::NotifyDependentChange();
+        }
+        return hr;
+    }
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 parentId,
+                                   _In_ PCWSTR pwszName,
+                                   _In_opt_ PCWSTR pwszQualifiedName)
+    {
+        return BaseInitialize(pSymbolSet, SvcSymbolType, SvcSymbolTypeUDT, parentId, pwszName, pwszQualifiedName);
+    }
+
+    // LayoutType():
+    //
+    // Performs a type layout.  This computes everything necessary about a type from its field layout including
+    // the offsets of fields, the size of the type, and any alignment padding necessary.
+    //
+    HRESULT LayoutType();
+
+private:
+
+};
+
+// PointerTypeSymbol:
+//
+// A symbol which represents a pointer to some other type
+//
+class PointerTypeSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseTypeSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolType:
+    //
+
+    // GetPointerKind():
+    //
+    // Returns what kind of pointer the type is (e.g.: a standard pointer, a pointer to member,
+    // a reference, an r-value reference, etc...
+    //
+    IFACEMETHOD(GetPointerKind)(_Out_ SvcSymbolPointerKind *pKind)
+    {
+        *pKind = m_pointerKind;
+        return S_OK;
+    }
+
+    // GetBaseType():
+    //
+    // If the type is a derivation of another single type (e.g.: as "MyStruct *" is derived from "MyStruct"),
+    // this returns the base type of the derivation.  For pointers, this would return the type pointed to.
+    // For arrays, this would return what the array is an array of.  If the type is not such a derivative
+    // type, an error is returned.
+    //
+    // Note that this method has nothing to do with C++ base classes.  Such are symbols which can be enumerated
+    // from the derived class.
+    //
+    IFACEMETHOD(GetBaseType)(_Out_ ISvcSymbol **ppBaseType);
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 pointerToId,
+                                   _In_ SvcSymbolPointerKind pointerKind);
+
+    // AppendPtrChar():
+    //
+    // Appends a character equivalent to the C++ (/CX) syntax for a given pointer type.
+    //
+    static void AppendPtrChar(_Inout_ std::wstring& str, 
+                              _In_ SvcSymbolPointerKind pointerKind,
+                              _In_ bool includeSpace = true)
+    {
+        if (includeSpace)
+        {
+            str += L" ";
+        }
+
+        switch(pointerKind)
+        {
+            case SvcSymbolPointerStandard:
+                str += L"*";
+                break;
+            
+            case SvcSymbolPointerReference:
+                str += L"&";
+                break;
+            
+            case SvcSymbolPointerRValueReference:
+                str += L"&&";
+                break;
+            
+            case SvcSymbolPointerCXHat:
+                str += L"^";
+                break;
+        }
+    }
+
+    //*************************************************
+    // Internal Accessors():
+    //
+    
+    ULONG64 InternalGetPointerToTypeId() const { return m_pointerToId; }
+
+private:
+
+    ULONG64 m_pointerToId;
+    SvcSymbolPointerKind m_pointerKind;
+
+};
+
+// ArrayTypeSymbol:
+//
+// A symbol which represents an array of some other type
+//
+class ArrayTypeSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseTypeSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolType:
+    //
+
+    // GetBaseType():
+    //
+    // If the type is a derivation of another single type (e.g.: as "MyStruct *" is derived from "MyStruct"),
+    // this returns the base type of the derivation.  For pointers, this would return the type pointed to.
+    // For arrays, this would return what the array is an array of.  If the type is not such a derivative
+    // type, an error is returned.
+    //
+    // Note that this method has nothing to do with C++ base classes.  Such are symbols which can be enumerated
+    // from the derived class.
+    //
+    IFACEMETHOD(GetBaseType)(_Out_ ISvcSymbol **ppBaseType);
+
+    // GetArrayDimensionality():
+    //
+    // Returns the dimensionality of the array.  There is no guarantee that every array type representable by
+    // these interfaces is a standard zero-based one dimensional array as is standard in C.
+    //
+    IFACEMETHOD(GetArrayDimensionality)(_Out_ ULONG64 *pArrayDimensionality)
+    {
+        *pArrayDimensionality = 1;
+        return S_OK;
+    }
+
+    // GetArrayDimensions():
+    //
+    // Fills in information about each dimension of the array including its lower bound, length, and
+    // stride.
+    //
+    IFACEMETHOD(GetArrayDimensions)(_In_ ULONG64 dimensions,
+                                    _Out_writes_(dimensions) SvcSymbolArrayDimension *pDimensions);
+
+    // GetArrayHeaderSize():
+    //
+    // Gets the size of any header of the array (this is the offset of the first element of the array as
+    // described by the dimensions).
+    //
+    // This should *ALWAYS* return 0 for a C style array.
+    //
+    IFACEMETHOD(GetArrayHeaderSize)(_Out_ ULONG64 *pArrayHeaderSize)
+    {
+        *pArrayHeaderSize = 0;
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 arrayOfId,
+                                   _In_ ULONG64 arrayDim);
+
+    // NotifyDependentChange():
+    //
+    // Called if the layout of the underlying type of the array changes, this allows us to recompute the layout
+    // of the array itself.
+    //
+    virtual HRESULT NotifyDependentChange();
+
+    // Delete():
+    //
+    // Called when this symbol is deleted.
+    //
+    virtual HRESULT Delete();
+
+    //*************************************************
+    // Internal Accessors():
+    //
+    
+    ULONG64 InternalGetArrayOfTypeId() const { return m_arrayOfTypeId; }
+    ULONG64 InternalGetArraySize() const { return m_arrayDim; }
+
+private:
+
+    ULONG64 m_arrayOfTypeId;
+    ULONG64 m_arrayDim;
+    ULONG64 m_baseTypeSize;
+
+};
+
+// TypedefTypeSymbol:
+//
+// A symbol which represents a typedef to some other type
+//
+class TypedefTypeSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseTypeSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolType:
+    //
+
+    // GetBaseType():
+    //
+    // If the type is a derivation of another single type (e.g.: as "MyStruct *" is derived from "MyStruct"),
+    // this returns the base type of the derivation.  For pointers, this would return the type pointed to.
+    // For arrays, this would return what the array is an array of.  If the type is not such a derivative
+    // type, an error is returned.
+    //
+    // Note that this method has nothing to do with C++ base classes.  Such are symbols which can be enumerated
+    // from the derived class.
+    //
+    IFACEMETHOD(GetBaseType)(_Out_ ISvcSymbol **ppBaseType);
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 typedefOfId,
+                                   _In_ ULONG64 parentId,
+                                   _In_ PCWSTR pwszName,
+                                   _In_opt_ PCWSTR pwszQualifiedName);
+
+    //*************************************************
+    // Internal Accessors():
+    //
+
+    ULONG64 InternalGetTypedefOfTypeId() const { return m_typedefOfTypeId; }
+
+private:
+
+    ULONG64 m_typedefOfTypeId;
+
+};
+
+// EnumTypeSymbol:
+//
+// A symbol which represents an enum
+//
+class EnumTypeSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseTypeSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // ISvcSymbolType:
+    //
+
+    // GetBaseType():
+    //
+    // If the type is a derivation of another single type (e.g.: as "MyStruct *" is derived from "MyStruct"),
+    // this returns the base type of the derivation.  For pointers, this would return the type pointed to.
+    // For arrays, this would return what the array is an array of.  If the type is not such a derivative
+    // type, an error is returned.
+    //
+    // Note that this method has nothing to do with C++ base classes.  Such are symbols which can be enumerated
+    // from the derived class.
+    //
+    IFACEMETHOD(GetBaseType)(_Out_ ISvcSymbol **ppBaseType);
+
+    // GetIntrinsicType():
+    //
+    // If the type kind as reported by GetTypeKind is an intrinsic, this returns more information about
+    // the particular kind of intrinsic.
+    //
+    IFACEMETHOD(GetIntrinsicType)(_Out_opt_ SvcSymbolIntrinsicKind *pKind,
+                                  _Out_opt_ ULONG *pPackingSize)
+    {
+        if (pKind != nullptr)
+        {
+            *pKind = m_enumIntrinsicKind;
+        }
+        if (pPackingSize != nullptr)
+        {
+            *pPackingSize = static_cast<ULONG>(m_typeSize);
+        }
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    virtual HRESULT NotifyDependentChange()
+    {
+        HRESULT hr = LayoutEnum();
+        if (SUCCEEDED(hr))
+        {
+            hr = BaseSymbol::NotifyDependentChange();
+        }
+        return hr;
+    }
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 basicEnumTypeId,
+                                   _In_ ULONG64 parentId,
+                                   _In_ PCWSTR pwszName,
+                                   _In_opt_ PCWSTR pwszQualifiedName);
+
+    // LayoutEnum():
+    //
+    // Performs an enum layout.  This computes everything necessary about an enum including the values
+    // of its auto-increment fields.
+    //
+    HRESULT LayoutEnum();
+
+    //*************************************************
+    // Internal Accessors():
+    //
+
+    ULONG64 InternalGetEnumBasicTypeId() const { return m_enumBasicTypeId; }
+    VARTYPE InternalGetEnumValuePacking() const { return m_enumPacking; }
+    SvcSymbolIntrinsicKind InternalGetEnumIntrinsicKind() { return m_enumIntrinsicKind; }
+
+private:
+
+    ULONG64 m_enumBasicTypeId;
+    SvcSymbolIntrinsicKind m_enumIntrinsicKind;
+    VARTYPE m_enumPacking;
+
+};
+
+// UdtPositionalSymbol:
+//
+// A symbol which is a child of a UDT that must be positioned within the UDT (e.g.: fields, base classes, etc...)
+//
+class UdtPositionalSymbol :
+    public Microsoft::WRL::Implements<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        BaseDataSymbol
+        >
+{
+public:
+
+    // AutomaticAppendLayout:
+    //
+    // A constant used for the field offsets which indicates that this field should be automatically
+    // laid out by the symbol builder.  It should just be considered appended to the end of the UDT
+    // declaration with offset determined by size/alignment.
+    //
+    static constexpr ULONG64 AutomaticAppendLayout = static_cast<ULONG64>(-2ll);
+
+    // AutomaticIncreaseConstantValue:
+    //
+    // A constant used for the field offsets which indicates that this field has a constant value and
+    // no other location.  In addition, the constant value is automatically generated in the style of
+    // a "C enum" where the value increases by 1 over the previous enumerant.
+    //
+    // This value may *ONLY* be used for an enumerant and not a general field.
+    //
+    static constexpr ULONG64 AutomaticIncreaseConstantValue = static_cast<ULONG64>(-3ll);
+
+    //*************************************************
+    // ISvcSymbol:
+    //
+
+    // GetOffset():
+    //
+    // Gets the offset of the symbol (if said symbol has such).  Note that if the symbol has multiple
+    // disjoint address ranges associated with it, this method may return S_FALSE to indicate that the symbol
+    // does not necessarily have a simple "base address" for an offset.
+    //
+    IFACEMETHOD(GetOffset)(_Out_ ULONG64 *pSymbolOffset)
+    {
+        //
+        // Our owning type had better have done layout by now!
+        //
+        if (m_symOffsetActual == AutomaticAppendLayout)
+        {
+            return E_UNEXPECTED;
+        }
+
+        *pSymbolOffset = m_symOffsetActual;
+        return S_OK;
+    }
+
+    //*************************************************
+    // ISvcSymbolInfo:
+    //
+
+    // GetLocation()
+    //
+    // Gets the location of the symbol.
+    //
+    IFACEMETHOD(GetLocation)(_Out_ SvcSymbolLocation *pLocation)
+    {
+        //
+        // If the field has a constant value, indicate this.
+        //
+        if (InternalIsConstantValue())
+        {
+            pLocation->Kind = SvcSymbolLocationConstantValue;
+            return S_OK;
+        }
+
+        //
+        // Our owning type had better have done layout by now!
+        //
+        if (m_symOffsetActual == AutomaticAppendLayout)
+        {
+            return E_UNEXPECTED;
+        }
+
+        pLocation->Kind = SvcSymbolLocationStructureRelative;
+        pLocation->Offset = m_symOffsetActual;
+        return S_OK;
+    }
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    // BaseInitialize():
+    //
+    // Initialize the positional symbol (as an offset based symbol)
+    //
+    HRESULT BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                           _In_ SvcSymbolKind symKind,
+                           _In_ ULONG64 owningTypeId,
+                           _In_ ULONG64 symOffset,
+                           _In_ ULONG64 symTypeId,
+                           _In_opt_ PCWSTR pwszName);
+
+    // BaseInitialize():
+    //
+    // Initialize the positional symbol (as a value based symbol).  Only fields can initialize in this way!
+    //
+    HRESULT BaseInitialize(_In_ SymbolSet *pSymbolSet,
+                           _In_ ULONG64 owningTypeId,
+                           _In_ VARIANT *pValue,
+                           _In_ ULONG64 symTypeId,
+                           _In_ PCWSTR pwszName);
+
+    // MoveToBefore():
+    //
+    // Moves this positional symbol to before another one in order.  This rearranges the object's children.
+    // If the object is not an automatic layout, this call doesn't do much.
+    //
+    HRESULT MoveToBefore(_In_ ULONG64 position);
+
+    //*************************************************
+    // Internal Accessors:
+    //
+
+    virtual bool InternalIsAutomaticLayout() const { return m_symOffset == AutomaticAppendLayout; }
+    virtual bool InternalIsIncreasingConstant() const { return m_symOffset == AutomaticIncreaseConstantValue; }
+    virtual bool InternalIsConstantValue() const { return m_symOffset == ConstantValue || m_symOffset == AutomaticIncreaseConstantValue; }
+    virtual bool InternalIsEnumerant() const { return InternalIsConstantValue() && !InternalHasType(); }
+
+    virtual ULONG64 InternalGetActualSymbolOffset() const { return m_symOffsetActual; }
+
+    //*************************************************
+    // Internal Computation Callbacks:
+    //
+
+    void InternalSetComputedSymbolOffset(_In_ ULONG64 offset) 
+    { 
+        if (m_symOffset == AutomaticAppendLayout)
+        {
+            m_symOffsetActual = offset;
+        }
+    }
+
+    void InternalSetComputedValue(_In_ VARIANT const& value)
+    {
+        if (m_symOffset == AutomaticIncreaseConstantValue)
+        {
+            m_symValue = value;
+        }
+    }
+
+protected:
+
+    ULONG64 m_symOffsetActual;          // Either hard coded or computed from automatic layout
+
+};
+        
+// FieldSymbol:
+//
+// A symbol which is a field of some user defined type.
+//
+class FieldSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        UdtPositionalSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    // RuntimeClassInitialize (normal field):
+    //
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 owningTypeId,
+                                   _In_ ULONG64 symOffset,
+                                   _In_ ULONG64 symTypeId,
+                                   _In_ PCWSTR pwszName)
+    {
+        return UdtPositionalSymbol::BaseInitialize(pSymbolSet,
+                                                   SvcSymbolField,
+                                                   owningTypeId,
+                                                   symOffset,
+                                                   symTypeId,
+                                                   pwszName);
+    }
+
+    // RuntimeClassInitialize (constant valued field):
+    //
+    // NOTE: An enumerant may legally pass "0" as symTypeId.  It inherits this from the enum
+    //       itself and each enumerant does *NOT* need a separate type.
+    //
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 owningTypeId,
+                                   _In_ ULONG64 symTypeId,
+                                   _In_ VARIANT *pValue,
+                                   _In_ PCWSTR pwszName)
+    {
+        return UdtPositionalSymbol::BaseInitialize(pSymbolSet,
+                                                   owningTypeId,
+                                                   pValue,
+                                                   symTypeId,
+                                                   pwszName);
+    }
+};
+
+// BaseClassSymbol:
+//
+// A symbol which is a base class of some user defined type.
+//
+class BaseClassSymbol :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>,
+        UdtPositionalSymbol
+        >
+{
+public:
+
+    //*************************************************
+    // Internal APIs:
+    //
+
+    HRESULT RuntimeClassInitialize(_In_ SymbolSet *pSymbolSet,
+                                   _In_ ULONG64 owningTypeId,
+                                   _In_ ULONG64 symOffset,
+                                   _In_ ULONG64 symTypeId)
+    {
+        return UdtPositionalSymbol::BaseInitialize(pSymbolSet,
+                                                   SvcSymbolBaseClass,
+                                                   owningTypeId,
+                                                   symOffset,
+                                                   symTypeId,
+                                                   nullptr);
+    }
+};
+
+} // SymbolBuilder
+} // Services
+} // TargetComposition
+} // Debugger
+
+#endif // __SYMBOLTYPES_H__

--- a/TargetComposition/SymBuilder/packages.config
+++ b/TargetComposition/SymBuilder/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.1" targetFramework="native" />
+  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.2" targetFramework="native" />
   <package id="Microsoft.Debugging.Platform.DbgEng" version="20220912.1623.0" targetFramework="native" />
   <package id="Microsoft.Debugging.TargetModel.SDK" version="20220912.1623.0" targetFramework="native" />
 </packages>

--- a/TargetComposition/SymBuilder/packages.config
+++ b/TargetComposition/SymBuilder/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.1" targetFramework="native" />
+  <package id="Microsoft.Debugging.Platform.DbgEng" version="20220912.1623.0" targetFramework="native" />
+  <package id="Microsoft.Debugging.TargetModel.SDK" version="20220912.1623.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
Adds a new sample of the debugger's target composition APIs.  The sample allows for the creation and manipulation of synthetic symbols which appear to the debugger largely the same as any other PDB or DWARF symbols.  In the initial version of this sample, UDTs can be created and manipulated as can global data.  Future revisions will add increasing levels of capability to the sample.

There is a detailed readme with the sample which walks through the APIs exposed to the data model as well as the overall structure and architecture of the sample.

NOTES:
    - This effectively *REQUIRES* WinDbg Preview from the Microsoft Store: version 1.2210.3001.0 or later.  While the sample will function on previous versions of the debugger, dynamic manipulation of types will require frequent .reloads.