### PR TITLE
Update Continuous-Integration.yml for Azure Pipelines

### DIFF
--- a/Exdi/exdigdbsrv/yaml/Continuous-Integration.yml
+++ b/Exdi/exdigdbsrv/yaml/Continuous-Integration.yml
@@ -2,7 +2,12 @@
 name: $(TeamProject)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger:
-- master
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - Exdi/exdigdbsrv
 
 pool:
   vmImage: 'windows-2022'


### PR DESCRIPTION
Limit the ExdiGdbServer pipeline to only run on cahnges to ExdiGdbServer