### PR TITLE
Update DbgX samples to use the latest dbgeng package

### DIFF
--- a/DbgX/GetDumpStack/GetDumpStack.csproj
+++ b/DbgX/GetDumpStack/GetDumpStack.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220510.3.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Microsoft.Debugging.Platform.DbgEng" Version="20220912.1623.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="$(MicrosoftDebuggingPlatformDbgEngContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+  </ItemGroup>
 </Project>

--- a/DbgX/GetDumpStack/GetDumpStack.csproj
+++ b/DbgX/GetDumpStack/GetDumpStack.csproj
@@ -12,9 +12,13 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgEng" Version="20220912.1623.0" />
+    <PackageReference Include="Microsoft.Debugging.Platform.SymSrv" Version="20220912.1623.0" />
+    <PackageReference Include="Microsoft.Debugging.Platform.SrcSrv" Version="20220912.1623.0" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="$(MicrosoftDebuggingPlatformDbgEngContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+    <None Include="$(MicrosoftDebuggingPlatformSrcSrvContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+    <None Include="$(MicrosoftDebuggingPlatformSymSrvContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/DbgX/SimpleDbgX/SimpleDbgX.csproj
+++ b/DbgX/SimpleDbgX/SimpleDbgX.csproj
@@ -10,6 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220510.3.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Debugging.Platform.DbgEng" Version="20220912.1623.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="$(MicrosoftDebuggingPlatformDbgEngContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+  </ItemGroup>
 </Project>

--- a/DbgX/SimpleDbgX/SimpleDbgX.csproj
+++ b/DbgX/SimpleDbgX/SimpleDbgX.csproj
@@ -11,9 +11,13 @@
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220510.3.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgEng" Version="20220912.1623.0" />
+    <PackageReference Include="Microsoft.Debugging.Platform.SymSrv" Version="20220912.1623.0" />
+    <PackageReference Include="Microsoft.Debugging.Platform.SrcSrv" Version="20220912.1623.0" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="$(MicrosoftDebuggingPlatformDbgEngContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+    <None Include="$(MicrosoftDebuggingPlatformSrcSrvContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+    <None Include="$(MicrosoftDebuggingPlatformSymSrvContent)**\*" CopyToOutputDirectory="Always" Visible="False" Link="%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The current DbgX nuget has an old version of dbgeng included. That should be removed, and consumers should reference instead the updated nuget DbgEng package.