### PR TITLE
Remove two assert statements

### DIFF
--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvRspClient.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvRspClient.cpp
@@ -842,7 +842,12 @@ bool GdbSrvRspClient<TcpConnectorStream>::ConfigRspSession(_In_ const RSP_CONFIG
         if (isAllCores || core == coreNumber)
         {
             TcpIpStream * pStream = m_pConnector->GetLinkLayerStreamEntry(coreNumber);
-            assert(pStream != nullptr);
+            if (pStream == nullptr)
+            {
+                // There is no any available connection
+                configDone = false;
+                break;
+            }
 
             //  Set the call back function
             if (pConfigData->pDisplayCommDataFunc != nullptr && pConfigData->pTextHandler != nullptr)

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.cpp
@@ -1259,8 +1259,7 @@ bool XmlDataGdbServerRegisterFile::HandleTargetFileTags(_In_ TAG_ATTR_LIST* cons
             }
             else
             {
-                assert(false);
-                isDone = false;
+                isDone = true;
             }
         }
     }


### PR DESCRIPTION
This PR is to handle the following:
1. The QEMU gdb server was sending a new target xml file (aarch64-pauth.xml), so the code was asserting since it does not handle such xml file. The fix will ignore a new target xml file sent by the GDB server, since currently, this assert was done to detect any new xml file that the ExdiGDbSrv client would handle, but it seems that this is causing a lot of support issues for things that we don't need it.
2. The second issue is provoked also by an assert condition when the user provides an invalid format of the Ip:Port string, so the exdiGdbSrv client will exit rather than asserting.