### PR TITLE
Added support for VMWare x64 arch.

### DIFF
--- a/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
+++ b/Exdi/exdigdbsrv/ExdiGdbSrv/LiveExdiGdbSrvServer.cpp
@@ -1205,21 +1205,30 @@ HRESULT STDMETHODCALLTYPE CLiveExdiGdbSrvServer::GetContextEx(_In_ DWORD process
         pContext->RegGroupSelection.fSegmentRegs = TRUE;
 
         //   Control registers (System registers)
-        pContext->RegCr0 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr0"]));
-        pContext->RegCr2 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr2"]));
-        pContext->RegCr3 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr3"]));
-        pContext->RegCr4 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr4"]));
-        pContext->RegCr8 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr8"]));
-        pContext->RegGroupSelection.fSystemRegisters = TRUE;
+        //   Control registers (System registers)
+        std::map<std::string, std::string> ::const_iterator it = registers.find("cr0");
+        if (it != registers.end())
+        {
+            pContext->RegCr0 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr0"]));
+            pContext->RegCr2 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr2"]));
+            pContext->RegCr3 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr3"]));
+            pContext->RegCr4 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr4"]));
+            pContext->RegCr8 = static_cast<DWORD>(GdbSrvController::ParseRegisterValue(registers["cr8"]));
+            pContext->RegGroupSelection.fSystemRegisters = TRUE;
+        }
 
         //  get all floating point registers (FPU)
-        pContext->ControlWord = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fctrl"]));
-        pContext->StatusWord = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fstat"]));
-        pContext->TagWord = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["ftag"]));
-        pContext->ErrorOffset = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fioff"]));
-        pContext->ErrorSelector = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fiseg"]));
-        pContext->DataOffset = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fooff"]));
-        pContext->DataSelector = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["foseg"]));
+        it = registers.find("fctrl");
+        if (it != registers.end())
+        {
+            pContext->ControlWord = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fctrl"]));
+            pContext->StatusWord = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fstat"]));
+            pContext->TagWord = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["ftag"]));
+            pContext->ErrorOffset = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fioff"]));
+            pContext->ErrorSelector = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fiseg"]));
+            pContext->DataOffset = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["fooff"]));
+            pContext->DataSelector = static_cast<DWORD>(GdbSrvController::ParseRegisterValue32(registers["foseg"]));
+        }
 
         //  x87 registers (FPU)
         for (int index = 0; index < s_numberFPRegList; ++index)

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
@@ -447,12 +447,85 @@
   <!-- VMWare GDB server configuration -->
   <ExdiTarget Name = "VMWare">
     <ExdiGdbServerConfigData agentNamePacket = "" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "no" >
-      <ExdiGdbServerTargetData targetArchitecture = "X86" targetFamily = "ProcessorFamilyX86" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xffe" targetDescriptionFile = "" />
+      <ExdiGdbServerTargetData targetArchitecture = "X64" targetFamily = "ProcessorFamilyX64" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xffe" targetDescriptionFile = "" />
       <GdbServerConnectionParameters MultiCoreGdbServerSessions = "no" MaximumGdbServerPacketLength = "1024" MaximumConnectAttempts = "3" SendPacketTimeout = "100" ReceivePacketTimeout = "3000" >
-        <Value HostNameAndPort="localhost:15360" />
+        <Value HostNameAndPort="localhost:1234" />
       </GdbServerConnectionParameters>
       <ExdiGdbServerMemoryCommands GdbSpecialMemoryCommand = "no" PhysicalMemory = "no" SupervisorMemory = "no" HypervisorMemory = "no" SpecialMemoryRegister = "no" SystemRegistersGdbMonitor = "no" SystemRegisterDecoding = "no">
       </ExdiGdbServerMemoryCommands>
+
+      <!-- x64 GDB server core resgisters -->
+
+      <ExdiGdbServerRegisters Architecture = "X64" FeatureNameSupported = "sys" SystemRegistersStart = "18" SystemRegistersEnd = "20" >
+        <Entry Name ="rax" Order = "0" Size ="8" />
+        <Entry Name ="rbx" Order = "1" Size ="8" />
+        <Entry Name ="rcx" Order = "2" Size ="8" />
+        <Entry Name ="rdx" Order = "3" Size ="8" />
+        <Entry Name ="rsi" Order = "4" Size ="8" />
+        <Entry Name ="rdi" Order = "5" Size ="8" />
+        <Entry Name ="rbp" Order = "6" Size ="8" />
+        <Entry Name ="rsp" Order = "7" Size ="8" />
+        <Entry Name ="r8"  Order = "8" Size ="8" />
+        <Entry Name ="r9"  Order = "9" Size ="8" />
+        <Entry Name ="r10" Order = "a" Size ="8" />
+        <Entry Name ="r11" Order = "b" Size ="8" />
+        <Entry Name ="r12" Order = "c" Size ="8" />
+        <Entry Name ="r13" Order = "d" Size ="8" />
+        <Entry Name ="r14" Order = "e" Size ="8" />
+        <Entry Name ="r15" Order = "f" Size ="8" />
+        <Entry Name ="rip" Order = "10" Size ="8" />
+        <!-- <flags id="i386_eflags" size="4">
+         <flags id="i386_eflags" size="4">
+         <field name="CF" start="0" end="0"/>
+         <field name="" start="1" end="1"/>
+         <field name="PF" start="2" end="2"/>
+         <field name="AF" start="4" end="4"/>
+         <field name="ZF" start="6" end="6"/>
+         <field name="SF" start="7" end="7"/>
+         <field name="TF" start="8" end="8"/>
+         <field name="IF" start="9" end="9"/>
+         <field name="DF" start="10" end="10"/>
+         <field name="OF" start="11" end="11"/>
+         <field name="NT" start="14" end="14"/>
+         <field name="RF" start="16" end="16"/>
+         <field name="VM" start="17" end="17"/>
+         <field name="AC" start="18" end="18"/>
+         <field name="VIF" start="19" end="19"/>
+         <field name="VIP" start="20" end="20"/>
+         <field name="ID" start="21" end="21"/>
+         </flags>
+        </flags> -->
+  
+      <Entry Name ="eflags" Order = "11" Size ="4" />
+        <!-- Segment registers -->
+        <Entry Name ="cs" Order = "12" Size ="4" />
+        <Entry Name ="ss" Order = "13" Size ="4" />
+        <Entry Name ="ds" Order = "14" Size ="4" />
+        <Entry Name ="es" Order = "15" Size ="4" />
+        <Entry Name ="fs" Order = "16" Size ="4" />
+        <Entry Name ="gs" Order = "17" Size ="4" />
+
+        <Entry Name ="st0" Order = "18" Size = "10" />
+        <Entry Name ="st1" Order = "19" Size = "10" />
+        <Entry Name ="st2" Order = "1a" Size = "10" />
+        <Entry Name ="st3" Order = "1b" Size = "10" />
+        <Entry Name ="st4" Order = "1c" Size = "10" />
+        <Entry Name ="st5" Order = "1d" Size = "10" />
+        <Entry Name ="st6" Order = "1e" Size = "10" />
+        <Entry Name ="st7" Order = "1f" Size = "10" />
+
+        <Entry Name ="fctrl" Order = "20" Size ="4" />
+        <Entry Name ="fstat" Order = "21" Size ="4" />
+        <Entry Name ="ftag"  Order = "22" Size ="4" />
+        <Entry Name ="fiseg" Order = "23" Size ="4" />
+        <Entry Name ="fioff" Order = "24" Size ="4" />
+        <Entry Name ="foseg" Order = "25" Size ="4" />
+        <Entry Name ="fooff" Order = "26" Size ="4" />
+        <Entry Name ="fop" Order = "27" Size ="4" />
+      </ExdiGdbServerRegisters>
+
+      <!-- x86 GDB server core resgisters -->
+
       <ExdiGdbServerRegisters Architecture = "x86">
         <Entry Name ="Eax" Order = "0" Size =  "4" />
         <Entry Name ="Ecx" Order = "1" Size =  "4" />


### PR DESCRIPTION
This PR enable debugging x64 VMWare Windows VMs.
Changes:
1. The exdiconfigdata.xml file has changed to include the x64 server.
2. The GetContext function has been updated to check for the existence of the x64 CR0, ... registers before trying to fecth them, since the VMWare GDB server does not support AMD64 CR0, CR1, etc. registers.
3. The ReadMemory function has been updated to be in synch with the GDBserver library changes in the Debugger internal depot.