### PR TITLE
Fix and update builds for current VS2022:

### DIFF
--- a/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/SimpleIntro.h
+++ b/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/SimpleIntro.h
@@ -12,6 +12,7 @@
 #include <wrl/client.h>
 #include <wrl/implements.h>
 #include <wrl/module.h>
+#include <new>
 
 // This is needed when using SDK version 10.0.17763.0
 // For newer versions of the SDK, this is not necessary

--- a/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/SimpleIntroClientLibrary.vcxproj
+++ b/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/SimpleIntroClientLibrary.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{8E623F5D-BA91-4C8A-9209-43703195D513}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SimpleIntroClientLibrary</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -72,15 +72,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -172,20 +176,38 @@
     <ClCompile Include="SimpleIntroExtension.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="amd64\dbgcore.dll" />
+    <None Include="amd64\dbgeng.dll" />
+    <None Include="amd64\dbghelp.dll" />
+    <None Include="amd64\dbgmodel.dll" />
+    <None Include="arm64\dbgcore.dll" />
+    <None Include="arm64\dbgeng.dll" />
+    <None Include="arm64\dbghelp.dll" />
+    <None Include="arm64\dbgmodel.dll" />
     <None Include="packages.config" />
     <None Include="SimpleIntro.def" />
+    <None Include="woa\dbgcore.dll" />
+    <None Include="woa\dbgeng.dll" />
+    <None Include="woa\dbghelp.dll" />
+    <None Include="woa\dbgmodel.dll" />
+    <None Include="x86\dbgcore.dll" />
+    <None Include="x86\dbgeng.dll" />
+    <None Include="x86\dbghelp.dll" />
+    <None Include="x86\dbgmodel.dll" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SimpleIntro.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
+    <Import Project="..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
+    <Import Project="..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets" Condition="Exists('..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets'))" />
   </Target>
 </Project>

--- a/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/SimpleIntroClientLibrary.vcxproj.filters
+++ b/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/SimpleIntroClientLibrary.vcxproj.filters
@@ -13,6 +13,18 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="x86">
+      <UniqueIdentifier>{8f748245-ad05-4762-ae93-9ef6439c21d6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="woa">
+      <UniqueIdentifier>{c5a1558b-2a5c-482f-90f5-1e4401b4884e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="arm64">
+      <UniqueIdentifier>{4cf77c3e-ffde-46b3-b38f-0aceaedfcac5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="amd64">
+      <UniqueIdentifier>{defc6e6c-d701-4825-a259-5c1102ea8267}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="HelloProvider.h">
@@ -38,6 +50,54 @@
       <Filter>Source Files</Filter>
     </None>
     <None Include="packages.config" />
+    <None Include="x86\dbgmodel.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="x86\dbghelp.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="x86\dbgeng.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="x86\dbgcore.dll">
+      <Filter>x86</Filter>
+    </None>
+    <None Include="woa\dbgmodel.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="woa\dbghelp.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="woa\dbgeng.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="woa\dbgcore.dll">
+      <Filter>woa</Filter>
+    </None>
+    <None Include="arm64\dbgmodel.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="arm64\dbghelp.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="arm64\dbgeng.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="arm64\dbgcore.dll">
+      <Filter>arm64</Filter>
+    </None>
+    <None Include="amd64\dbgmodel.dll">
+      <Filter>amd64</Filter>
+    </None>
+    <None Include="amd64\dbghelp.dll">
+      <Filter>amd64</Filter>
+    </None>
+    <None Include="amd64\dbgeng.dll">
+      <Filter>amd64</Filter>
+    </None>
+    <None Include="amd64\dbgcore.dll">
+      <Filter>amd64</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SimpleIntro.rc">

--- a/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/packages.config
+++ b/DataModelHelloWorld/Cpp/SimpleIntroClientLibrary/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.0" targetFramework="native" />
+  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.3" targetFramework="native" />
+  <package id="Microsoft.Debugging.Platform.DbgEng" version="20230328.919.0" targetFramework="native" />
 </packages>

--- a/DataModelHelloWorld/RawCOM/SimpleIntroRawCOM/SimpleIntro.h
+++ b/DataModelHelloWorld/RawCOM/SimpleIntroRawCOM/SimpleIntro.h
@@ -12,6 +12,7 @@
 #include <wrl/client.h>
 #include <wrl/implements.h>
 #include <wrl/module.h>
+#include <new>
 
 using namespace Microsoft::WRL;
 

--- a/DataModelHelloWorld/RawCOM/SimpleIntroRawCOM/SimpleIntroRawCOM.vcxproj
+++ b/DataModelHelloWorld/RawCOM/SimpleIntroRawCOM/SimpleIntroRawCOM.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{B01D0F49-77C0-4BE1-BF5A-1176F58CCAAF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SimpleIntroRawCOM</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/TargetComposition/SymBuilder/SymBuilder.vcxproj
+++ b/TargetComposition/SymBuilder/SymBuilder.vcxproj
@@ -120,19 +120,19 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
     <TargetName>SymbolBuilderComposition</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
     <TargetName>SymbolBuilderComposition</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
     <TargetName>SymbolBuilderComposition</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\native\inc;$(IncludePath)</IncludePath>
+    <IncludePath>packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\native\inc;$(IncludePath)</IncludePath>
     <TargetName>SymbolBuilderComposition</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -221,16 +221,16 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets" Condition="Exists('packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" />
-    <Import Project="packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets" Condition="Exists('packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" />
-    <Import Project="packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
+    <Import Project="packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets" Condition="Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" />
+    <Import Project="packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets" Condition="Exists('packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" />
+    <Import Project="packages\Microsoft.Debugging.TargetModel.SDK.20230328.919.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets" Condition="Exists('packages\Microsoft.Debugging.TargetModel.SDK.20230328.919.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.TargetModel.SDK.20220912.1623.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.Platform.DbgEng.20220912.1623.0\build\Microsoft.Debugging.Platform.DbgEng.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.DataModel.CppLib.1.0.2\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.DataModel.CppLib.1.0.3\build\native\Microsoft.Debugging.DataModel.CppLib.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.Platform.DbgEng.20230328.919.0\build\Microsoft.Debugging.Platform.DbgEng.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Debugging.TargetModel.SDK.20230328.919.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Debugging.TargetModel.SDK.20230328.919.0\build\native\Microsoft.Debugging.TargetModel.SDK.targets'))" />
   </Target>
 </Project>

--- a/TargetComposition/SymBuilder/SymBuilder.vcxproj.filters
+++ b/TargetComposition/SymBuilder/SymBuilder.vcxproj.filters
@@ -1,154 +1,52 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
-    <Filter Include="x86">
-      <UniqueIdentifier>{d33ecf74-f353-4067-8906-5bd388c3a475}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="woa">
-      <UniqueIdentifier>{8c5b8740-4dc4-49bc-8d1b-90bd1de57aad}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="arm64">
-      <UniqueIdentifier>{99cf6baf-372a-4a7c-b717-6e791843283a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="amd64">
-      <UniqueIdentifier>{52586b47-9960-48d9-a656-88cc97c57cfb}</UniqueIdentifier>
-    </Filter>
+    <ClCompile Include="ApiProvider.cpp" />
+    <ClCompile Include="Extension.cpp" />
+    <ClCompile Include="ImportSymbols.cpp" />
+    <ClCompile Include="SymbolBase.cpp" />
+    <ClCompile Include="SymbolData.cpp" />
+    <ClCompile Include="SymbolFunction.cpp" />
+    <ClCompile Include="SymbolServices.cpp" />
+    <ClCompile Include="SymbolSet.cpp" />
+    <ClCompile Include="SymbolTypes.cpp" />
+    <ClCompile Include="SymManager.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="ApiProvider.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Extension.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymbolBase.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymbolData.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymbolServices.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymbolSet.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymbolTypes.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymManager.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SymbolFunction.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ImportSymbols.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>    
+    <ClInclude Include="ApiProvider.h" />
+    <ClInclude Include="HelpStrings.h" />
+    <ClInclude Include="ImportSymbols.h" />
+    <ClInclude Include="InternalGuids.h" />
+    <ClInclude Include="ObjectModel.h" />
+    <ClInclude Include="SymbolBase.h" />
+    <ClInclude Include="SymbolData.h" />
+    <ClInclude Include="SymbolFunction.h" />
+    <ClInclude Include="SymbolServices.h" />
+    <ClInclude Include="SymbolSet.h" />
+    <ClInclude Include="SymbolTypes.h" />
+    <ClInclude Include="SymBuilder.h" />
+    <ClInclude Include="SymManager.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="ApiProvider.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="HelpStrings.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="InternalGuids.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ObjectModel.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymbolBase.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymbolData.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymbolServices.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymbolSet.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymbolTypes.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymBuilder.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SymManager.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ResourceCompile Include="SymBuilder.rc" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="amd64\dbgcore.dll" />
+    <None Include="amd64\dbgeng.dll" />
+    <None Include="amd64\dbghelp.dll" />
+    <None Include="amd64\dbgmodel.dll" />
+    <None Include="arm64\dbgcore.dll" />
+    <None Include="arm64\dbgeng.dll" />
+    <None Include="arm64\dbghelp.dll" />
+    <None Include="arm64\dbgmodel.dll" />
     <None Include="packages.config" />
-    <None Include="x86\dbgmodel.dll">
-      <Filter>x86</Filter>
-    </None>
-    <None Include="x86\dbghelp.dll">
-      <Filter>x86</Filter>
-    </None>
-    <None Include="x86\dbgeng.dll">
-      <Filter>x86</Filter>
-    </None>
-    <None Include="x86\dbgcore.dll">
-      <Filter>x86</Filter>
-    </None>
-    <None Include="woa\dbgmodel.dll">
-      <Filter>woa</Filter>
-    </None>
-    <None Include="woa\dbghelp.dll">
-      <Filter>woa</Filter>
-    </None>
-    <None Include="woa\dbgeng.dll">
-      <Filter>woa</Filter>
-    </None>
-    <None Include="woa\dbgcore.dll">
-      <Filter>woa</Filter>
-    </None>
-    <None Include="arm64\dbgmodel.dll">
-      <Filter>arm64</Filter>
-    </None>
-    <None Include="arm64\dbghelp.dll">
-      <Filter>arm64</Filter>
-    </None>
-    <None Include="arm64\dbgeng.dll">
-      <Filter>arm64</Filter>
-    </None>
-    <None Include="arm64\dbgcore.dll">
-      <Filter>arm64</Filter>
-    </None>
-    <None Include="amd64\dbgmodel.dll">
-      <Filter>amd64</Filter>
-    </None>
-    <None Include="amd64\dbghelp.dll">
-      <Filter>amd64</Filter>
-    </None>
-    <None Include="amd64\dbgeng.dll">
-      <Filter>amd64</Filter>
-    </None>
-    <None Include="amd64\dbgcore.dll">
-      <Filter>amd64</Filter>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="SymBuilder.rc">
-      <Filter>Resource Files</Filter>
-    </ResourceCompile>
+    <None Include="woa\dbgcore.dll" />
+    <None Include="woa\dbgeng.dll" />
+    <None Include="woa\dbghelp.dll" />
+    <None Include="woa\dbgmodel.dll" />
+    <None Include="x86\dbgcore.dll" />
+    <None Include="x86\dbgeng.dll" />
+    <None Include="x86\dbghelp.dll" />
+    <None Include="x86\dbgmodel.dll" />
   </ItemGroup>
 </Project>

--- a/TargetComposition/SymBuilder/packages.config
+++ b/TargetComposition/SymBuilder/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.2" targetFramework="native" />
-  <package id="Microsoft.Debugging.Platform.DbgEng" version="20220912.1623.0" targetFramework="native" />
-  <package id="Microsoft.Debugging.TargetModel.SDK" version="20220912.1623.0" targetFramework="native" />
+  <package id="Microsoft.Debugging.DataModel.CppLib" version="1.0.3" targetFramework="native" />
+  <package id="Microsoft.Debugging.Platform.DbgEng" version="20230328.919.0" targetFramework="native" />
+  <package id="Microsoft.Debugging.TargetModel.SDK" version="20230328.919.0" targetFramework="native" />
 </packages>

--- a/TargetComposition/TextDump/TextDump.vcxproj
+++ b/TargetComposition/TextDump/TextDump.vcxproj
@@ -55,26 +55,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
    - Update projects to compile with latest VS2022
    - Update NuGET references for DbgEng and the C++ lib to get rid of C++ compliance warnings/errors from more recent compilers
    - Include <new> in a few places to remove "std::bad_alloc" undefined issues
    - Update DataModelHelloWorld sample to pull DbgEng core headers from NuGET instead of SDK as the 1.0.3 CppLib NuGET will no longer compile with the older SDK headers due to missing definitions.  Such definitions are in the more up to date NuGET package