### PR TITLE
Add a TTD live recorder API sample.

### DIFF
--- a/TTD/LiveRecorderApiSample/.gitignore
+++ b/TTD/LiveRecorderApiSample/.gitignore
@@ -1,0 +1,2 @@
+TTDDownload
+out

--- a/TTD/LiveRecorderApiSample/Get-Ttd.cmd
+++ b/TTD/LiveRecorderApiSample/Get-Ttd.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call powershell "%~dp0\Get-Ttd.ps1" %*

--- a/TTD/LiveRecorderApiSample/Get-Ttd.ps1
+++ b/TTD/LiveRecorderApiSample/Get-Ttd.ps1
@@ -1,0 +1,79 @@
+param(
+    $OutDir = ".\TTDDownload",
+    [ValidateSet("x64", "x86", "arm64")]
+    $Arch = "x64",
+    $MsixBundle = ""
+)
+
+# Ensure the output directory exists
+if (!(Test-Path $OutDir)) {
+    $null = mkdir $OutDir
+}
+
+# Ensure the temp directory exists
+$TempDir = Join-Path $OutDir "TempTtd"
+if (!(Test-Path $TempDir)) {
+    $null = mkdir $TempDir
+}
+
+$MsixBundleZip = "$TempDir\ttd.zip"
+
+if ($MsixBundle -eq "") {
+    Write-Host "Downloading TTD from https://aka.ms/ttd/download"
+
+    # Download the appinstaller to find the current uri for the msixbundle
+    Invoke-WebRequest https://aka.ms/ttd/download -OutFile $TempDir\ttd.appinstaller
+
+    # Download the msixbundle
+    $msixBundleUri = ([xml](Get-Content $TempDir\ttd.appinstaller)).AppInstaller.MainBundle.Uri
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        # This is a workaround to get better performance on older versions of PowerShell
+        $ProgressPreference = 'SilentlyContinue'
+    }
+
+    # Download the msixbundle (but name as zip for older versions of Expand-Archive)
+    Invoke-WebRequest $msixBundleUri -OutFile $MsixBundleZip
+} else {
+    # Copy and rename the bundle so it can be expanded.
+    Copy-Item $MsixBundle -Destination $MsixBundleZip
+}
+
+# Extract the 3 msix files (plus other files)
+Expand-Archive -DestinationPath $TempDir\UnzippedBundle $MsixBundleZip -Force
+
+# We only need these file types.
+$extensions = @('.dll', '.exe')
+
+$ttdRecorderFiles = @(
+    "TTD.exe",
+    "TTDInject.exe",
+    "TTDLiveRecorder.dll",
+    "TTDLoader.dll",
+    "TTDRecord.dll",
+    "TTDRecordCPU.dll"
+)
+
+foreach ($archName in @("x64", "x86", "ARM64")) {
+    $msixName = "TTD-$archName"
+    $msixOutDir = "$OutDir\$archName"
+
+    if (!(Test-Path $msixOutDir)) {
+        $null = mkdir $msixOutDir
+    }
+
+    # Rename msix (for older versions of Expand-Archive) and extract TTD.
+    Rename-Item "$TempDir\UnzippedBundle\$msixName.msix" "$msixName.zip"
+    Expand-Archive -DestinationPath $msixOutDir "$TempDir\UnzippedBundle\$msixName.zip" -Force
+
+    # Remove unnecessary files
+    Get-ChildItem -Recurse -File $msixOutDir -Exclude $ttdRecorderFiles |
+        Remove-Item -Force
+
+    # Remove subdirectories
+    Get-ChildItem -Directory $msixOutDir |
+        Remove-Item -Recurse -Force
+}
+
+# Delete the temp directory
+Remove-Item $TempDir -Recurse -Force

--- a/TTD/LiveRecorderApiSample/LiveRecorderApiSample.sln
+++ b/TTD/LiveRecorderApiSample/LiveRecorderApiSample.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34310.174
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiveRecorderApiSample", "LiveRecorderApiSample.vcxproj", "{890F9EFE-0035-41C7-A51C-E4E1981B8D75}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Debug|ARM64.Build.0 = Debug|ARM64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Debug|x64.ActiveCfg = Debug|x64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Debug|x64.Build.0 = Debug|x64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Debug|x86.ActiveCfg = Debug|Win32
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Debug|x86.Build.0 = Debug|Win32
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Release|ARM64.ActiveCfg = Release|ARM64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Release|ARM64.Build.0 = Release|ARM64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Release|x64.ActiveCfg = Release|x64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Release|x64.Build.0 = Release|x64
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Release|x86.ActiveCfg = Release|Win32
+		{890F9EFE-0035-41C7-A51C-E4E1981B8D75}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2F6D99C8-E739-42EA-B5F2-B97B98C45358}
+	EndGlobalSection
+EndGlobal

--- a/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj
+++ b/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj
@@ -133,6 +133,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>TTDLiveRecorder.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -150,6 +151,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>TTDLiveRecorder.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -163,6 +165,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>TTDLiveRecorder.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -176,6 +179,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>TTDLiveRecorder.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -193,6 +197,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>TTDLiveRecorder.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -210,6 +215,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>TTDLiveRecorder.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj
+++ b/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props" Condition="Exists('packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props')" />
+  <Import Project="packages\Microsoft.TimeTravelDebugging.Apis.0.8.127\build\native\Microsoft.TimeTravelDebugging.Apis.props" Condition="Exists('packages\Microsoft.TimeTravelDebugging.Apis.0.8.127\build\native\Microsoft.TimeTravelDebugging.Apis.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -224,8 +224,8 @@
   <ItemGroup>
     <None Include="Get-Ttd.cmd" />
     <None Include="Get-Ttd.ps1" />
-    <None Include="README.md" />
     <None Include="packages.config" />
+    <None Include="README.md" />
     <CopyFileToFolders Include="TTDDownload\ARM64\TTD.exe">
       <FileType>Document</FileType>
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(OutDir)TTD\</DestinationFolders>
@@ -389,6 +389,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.TimeTravelDebugging.Apis.0.8.127\build\native\Microsoft.TimeTravelDebugging.Apis.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.TimeTravelDebugging.Apis.0.8.127\build\native\Microsoft.TimeTravelDebugging.Apis.props'))" />
   </Target>
 </Project>

--- a/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj
+++ b/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props" Condition="Exists('packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props')" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{890f9efe-0035-41c7-a51c-e4e1981b8d75}</ProjectGuid>
+    <RootNamespace>LiveRecorderApiSample</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)out\$(PlatformTarget)-$(Configuration)\</OutDir>
+    <IntDir>$(ShortProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <OutDir>$(SolutionDir)out\$(PlatformTarget)-$(Configuration)\</OutDir>
+    <IntDir>$(ShortProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)out\$(PlatformTarget)-$(Configuration)\</OutDir>
+    <IntDir>$(ShortProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)out\$(PlatformTarget)-$(Configuration)\</OutDir>
+    <IntDir>$(ShortProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)out\$(PlatformTarget)-$(Configuration)\</OutDir>
+    <IntDir>$(ShortProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)out\$(PlatformTarget)-$(Configuration)\</OutDir>
+    <IntDir>$(ShortProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Get-Ttd.cmd" />
+    <None Include="Get-Ttd.ps1" />
+    <None Include="README.md" />
+    <None Include="packages.config" />
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTD.exe">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDInject.exe">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDLiveRecorder.dll">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDLoader.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDRecord.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDRecordCPU.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTD.exe">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDInject.exe">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDLiveRecorder.dll">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDLoader.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDRecord.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDRecordCPU.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTD.exe">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDInject.exe">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDLiveRecorder.dll">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDLoader.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDRecord.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDRecordCPU.dll">
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)TTD\</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CopyFileToFolders>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.TimeTravelDebugging.Apis.0.8.123\build\native\Microsoft.TimeTravelDebugging.Apis.props'))" />
+  </Target>
+</Project>

--- a/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj.filters
+++ b/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj.filters
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="TTDDownload">
+      <UniqueIdentifier>{cf3a08f0-d087-44fa-bafd-dc590dfb36ff}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="TTDDownload\x86">
+      <UniqueIdentifier>{2e8d1099-cd2b-411e-a86c-8bc808f59d91}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="TTDDownload\x64">
+      <UniqueIdentifier>{68437d70-6688-45bf-a482-254ec13d63dc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="TTDDownload\ARM64">
+      <UniqueIdentifier>{1c6e87f3-af94-485a-97a6-b2aa091750b8}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Get-Ttd.cmd" />
+    <None Include="Get-Ttd.ps1" />
+    <None Include="README.md" />
+    <None Include="packages.config" />
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTD.exe">
+      <Filter>TTDDownload\ARM64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDInject.exe">
+      <Filter>TTDDownload\ARM64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDLiveRecorder.dll">
+      <Filter>TTDDownload\ARM64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDLoader.dll">
+      <Filter>TTDDownload\ARM64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDRecord.dll">
+      <Filter>TTDDownload\ARM64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\ARM64\TTDRecordCPU.dll">
+      <Filter>TTDDownload\ARM64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTD.exe">
+      <Filter>TTDDownload\x86</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDInject.exe">
+      <Filter>TTDDownload\x86</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDLiveRecorder.dll">
+      <Filter>TTDDownload\x86</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDLoader.dll">
+      <Filter>TTDDownload\x86</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDRecord.dll">
+      <Filter>TTDDownload\x86</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x86\TTDRecordCPU.dll">
+      <Filter>TTDDownload\x86</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTD.exe">
+      <Filter>TTDDownload\x64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDInject.exe">
+      <Filter>TTDDownload\x64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDLiveRecorder.dll">
+      <Filter>TTDDownload\x64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDLoader.dll">
+      <Filter>TTDDownload\x64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDRecord.dll">
+      <Filter>TTDDownload\x64</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TTDDownload\x64\TTDRecordCPU.dll">
+      <Filter>TTDDownload\x64</Filter>
+    </CopyFileToFolders>
+  </ItemGroup>
+</Project>

--- a/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj.filters
+++ b/TTD/LiveRecorderApiSample/LiveRecorderApiSample.vcxproj.filters
@@ -35,7 +35,6 @@
     <None Include="Get-Ttd.cmd" />
     <None Include="Get-Ttd.ps1" />
     <None Include="README.md" />
-    <None Include="packages.config" />
     <CopyFileToFolders Include="TTDDownload\ARM64\TTD.exe">
       <Filter>TTDDownload\ARM64</Filter>
     </CopyFileToFolders>
@@ -90,5 +89,6 @@
     <CopyFileToFolders Include="TTDDownload\x64\TTDRecordCPU.dll">
       <Filter>TTDDownload\x64</Filter>
     </CopyFileToFolders>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/TTD/LiveRecorderApiSample/README.md
+++ b/TTD/LiveRecorderApiSample/README.md
@@ -14,11 +14,11 @@ After that is done, open LiveRecorderApiSample.sln in Visual Studio 2022 16.8 or
 
 ## Dependencies
 
-Apart from TTD's binaries, this sample requires the `Microsoft.TimeTravelDebugging.Apis` NuGet package that provides the API.
+Apart from TTD's binaries, this sample requires the [`Microsoft.TimeTravelDebugging.Apis` NuGet package](https://www.nuget.org/packages/Microsoft.TimeTravelDebugging.Apis) that provides the API.
 This is downloaded automatically from the feed at https://nuget.org if it's configured in Visual Studio.
-(TODO: provide a link to the package's page)
 
-The API documentation can be found here (TODO: Provide link to documentation).
+
+The API documentation can be found here: https://github.com/microsoft/WinDbg-Samples/tree/master/TTD/docs
 
 ## Running the sample
 

--- a/TTD/LiveRecorderApiSample/README.md
+++ b/TTD/LiveRecorderApiSample/README.md
@@ -1,0 +1,79 @@
+# TTD live recorder API sample
+
+This is a sample demonstrating how a program can use TTD's live recording API to record portions of itself.
+
+## Getting Started
+
+A copy of TTD's recorder binaries is needed in order to build and run this sample.
+There are general instructions describing how to obtain the binaries documented in [How to download and install the TTD.exe command line utility (Offline method)](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-exe-command-line-util#how-to-download-and-install-the-ttdexe-command-line-utility-offline-method)
+
+For the purposes of this sample, you can just run the provided script `.\Get-Ttd` from a command or powershell window.
+This script downloads the most current binaries into a TTDDownload subdirectory.
+
+After that is done, open LiveRecorderApiSample.sln in Visual Studio 2022 16.8 or newer and build an appropriate configuration with F5. The sample builds and works for x64, x86 and ARM64.
+
+## Dependencies
+
+Apart from TTD's binaries, this sample requires the `Microsoft.TimeTravelDebugging.Apis` NuGet package that provides the API.
+This is downloaded automatically from the feed at https://nuget.org if it's configured in Visual Studio.
+(TODO: provide a link to the package's page)
+
+The API documentation can be found here (TODO: Provide link to documentation).
+
+## Running the sample
+
+When the sample is run, it will ask for the administrator pin or password because TTD requires admin privileges in order to record.
+Note that the sample itself will not run as admin, only TTD's command-line tool TTD.exe as invoked by the sample.
+
+After the admin request is granted the sample will run and record several portions of itself. The output will look like this:
+
+```
+Trace file: X:\repos\Microsoft\WinDbg-Samples\TTD\LiveRecorderApiSample\out\x64-Debug\LiveRecorderApiSample01.run
+All done!
+```
+
+This provides the full path to the trace file that was recorded. This trace file can then be loaded into [WinDbg](https://aka.ms/WinDbg), where it will show like this:
+
+```
+...
+Time Travel Position: 42:0
+TTDRecordCPU!InitializeNirvanaClient+0x7c69:
+       00007ffe`629f5b39 488b4df8        mov     rcx,qword ptr [rbp-8] ss:00000051`8031d4e8=0000c6709491b298
+0:000> k
+ # Child-SP          RetAddr               Call Site
+00 00000051`8031d490 00007ffe`f8981404     TTDRecordCPU!InitializeNirvanaClient+0x7c69
+01 00000051`8031d500 00007ff6`3f8c9923     TTDLiveRecorder+0x1404
+02 00000051`8031d540 00007ff6`3f8eae95     LiveRecorderApiSample!TTD::ILiveRecorder::StartRecordingCurrentThread+0x63 [X:\repos\Microsoft\WinDbg-Samples\TTD\LiveRecorderApiSample\packages\Microsoft.TimeTravelDebugging.Apis.0.8.0-TTDLiveRecordingBringup.1\include\TTD\TTDLiveRecorder.h @ 184] 
+03 00000051`8031d660 00007ff6`3f902609     LiveRecorderApiSample!wmain+0x6c5 [X:\repos\Microsoft\WinDbg-Samples\TTD\LiveRecorderApiSample\main.cpp @ 147] 
+...
+```
+
+Metadata recorded from the API can be examined in the debugger using the data model. For instance:
+
+```
+0:000> dx -r1 @$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"]
+@$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"]                 : Record client with GUID 6DA58208-3BF5-4B80-A711-781098BC4445 and lifetime: [40:0, 12A90:0]
+    Lifetime         : [40:0, 12A90:0]
+    OpenUserData     : 14 bytes ( 48 65 6C 6C 6F 2C 20 74 68 65 72 65 21 00 )
+    CloseUserData    : 7 bytes ( 41 64 69 6F 73 21 00 )
+    Activities      
+0:000> dx -r1 @$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"].Activities
+@$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"].Activities                
+    [0x0]            : Activity 1 with lifetime: [41:0, 4FE:0]
+    [0x1]            : Activity 2 with lifetime: [4FF:0, FFFFFFFFFFFFFFFE:0]
+0:000> dx -r1 @$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"].Activities[1]
+@$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"].Activities[1]                 : Activity 2 with lifetime: [4FF:0, FFFFFFFFFFFFFFFE:0]
+    Id               : 0x2
+    Lifetime         : [4FF:0, FFFFFFFFFFFFFFFE:0]
+    Islands         
+0:000> dx -r1 @$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"].Activities[1].Islands
+@$curprocess.TTD.RecordClients["6DA58208-3BF5-4B80-A711-781098BC4445"].Activities[1].Islands                
+    [0x0]            : Island on activity 2 from client 6DA58208-3BF5-4B80-A711-781098BC4445 on thread 2 (0x16200) with lifetime: [4FF:0, FFFFFFFFFFFFFFFE:0]
+    [0x1]            : Island on activity 2 from client 6DA58208-3BF5-4B80-A711-781098BC4445 on thread 3 (0x150D4) with lifetime: [509:0, FFFFFFFFFFFFFFFE:0]
+    [0x2]            : Island on activity 2 from client 6DA58208-3BF5-4B80-A711-781098BC4445 on thread 4 (0x10DF0) with lifetime: [516:0, FFFFFFFFFFFFFFFE:0]
+...
+    [0x61]           : Island on activity 2 from client 6DA58208-3BF5-4B80-A711-781098BC4445 on thread 32 (0x10C3C) with lifetime: [C32A:0, C65E:0]
+    [0x62]           : Island on activity 2 from client 6DA58208-3BF5-4B80-A711-781098BC4445 on thread 6 (0xC910) with lifetime: [C6E7:0, CABE:0]
+    [0x63]           : Island on activity 2 from client 6DA58208-3BF5-4B80-A711-781098BC4445 on thread 52 (0xFB3C) with lifetime: [C788:0, C9C1:0]
+    [...]           
+```

--- a/TTD/LiveRecorderApiSample/main.cpp
+++ b/TTD/LiveRecorderApiSample/main.cpp
@@ -1,0 +1,182 @@
+#include <Windows.h>
+
+#include <thread>
+#include <future>
+#include <filesystem>
+#include <format>
+#include <iostream>
+#include <random>
+#include <span>
+
+#include <TTD/TTDLiveRecorder.h>
+
+#pragma comment(lib, "TTDLiveRecorder")
+
+// {6DA58208-3BF5-4B80-A711-781098BC4445}
+static constexpr GUID ClientGuid = { 0x6da58208, 0x3bf5, 0x4b80, { 0xa7, 0x11, 0x78, 0x10, 0x98, 0xbc, 0x44, 0x45 } };
+
+// We define what the activity IDs mean.
+constexpr TTD::ActivityId StdSortActivity          { 1 };   // Call a std::sort function.
+constexpr TTD::ActivityId MultithreadedSortActivity{ 2 };   // A multithreaded sort.
+
+// We wish to report recording states by name.
+char const* GetStateName(TTD::ThreadRecordingState state)
+{
+    switch (state)
+    {
+    case TTD::ThreadRecordingState::NotStarted: return "NotStarted";
+    case TTD::ThreadRecordingState::Paused    : return "Paused";
+    case TTD::ThreadRecordingState::Recording : return "Recording";
+    case TTD::ThreadRecordingState::Throttled : return "Throttled";
+    default                                   : return "<unknown state>";
+    }
+}
+
+// Multithreaded sort function.
+// This algorithm splits the sorted range in two and runs one of the two pieces asynchronously.
+// It then merges the two pieces together, in-place.
+// it does this recursively: each of the two pieces is in turn split,
+// down to a reasonably (arbitrary) small size which is then sorted using std::sort.
+void MultithreadedSort(TTD::ILiveRecorder* pRecorder, std::span<int> span)
+{
+    if (span.size() <= 100)
+    {
+        std::ranges::sort(span);
+    }
+    else
+    {
+        auto const midPoint = span.size() / 2;
+        auto const loSpan = span.subspan(0, midPoint);
+        auto const hiSpan = span.subspan(midPoint);
+
+        auto const hiSpanFuture = std::async([pRecorder, hiSpan]()
+            {
+                // Asynchronous sorting of the hi span half.
+                // This gets to run on a separate thread,
+                // so in order to record we need to do it explicitly.
+                pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Max);
+                MultithreadedSort(pRecorder, hiSpan);
+                pRecorder->StopRecordingCurrentThread();
+            });
+
+        // While the hi span half is being sorted asynchronously,
+        // we will sort the low span half.
+        MultithreadedSort(pRecorder, loSpan);
+
+        // Before merging, we ensure the hi span half sort is complete.
+        hiSpanFuture.wait();
+
+        // Merge the two halves into a single sorted span.
+        std::ranges::inplace_merge(span, span.begin() + midPoint);
+    }
+}
+
+int wmain(int argc, wchar_t const* const* argv)
+{
+    std::default_random_engine rand{ std::random_device{}() };
+    std::uniform_int randInt{};
+
+    std::vector<int> randomSequence;
+    randomSequence.reserve(10000);
+    for (size_t i = 0; i < 10000; ++i)
+    {
+        randomSequence.push_back(randInt(rand));
+    }
+
+    std::filesystem::path binDir = std::filesystem::absolute(argv[0]).parent_path();
+
+    // In order to record ourselves we will launch our own copy of TTD.exe.
+    // We will then wait for it to signal that the process is ready to record.
+
+    // We use a simple named event as the signal.
+    std::wstring eventName = L"LiveRecorderApiSampleRecordingStarted";
+    HANDLE recordingStartedEvent = CreateEventW(nullptr, FALSE, FALSE, eventName.c_str());
+    if (recordingStartedEvent == nullptr)
+    {
+        std::wcerr << std::format(L"Couldn't create the '{}' named event. Error: {}\n", eventName.c_str(), GetLastError());
+        return 1;
+    }
+
+    // We need to run TTD.exe using ShellExecuteW, so we can request elevation.
+    // We need to do this from another thread because 
+//    std::thread(
+//        [=]()
+//        {
+            auto const arguments = std::format(LR"(-out {} -attach {} -onInitCompleteEvent {} -recordMode manual)",
+                binDir.native(),
+                GetCurrentProcessId(),
+                eventName
+            );
+            ShellExecuteW(
+                nullptr,
+                L"runas",
+                //L"TTD.exe",
+                (binDir / L"TTD" / L"TTD.exe").c_str(),
+                arguments.c_str(),
+                nullptr,
+                SW_SHOWNORMAL
+            );
+//        }
+//    ).detach();
+
+    if (WaitForSingleObject(recordingStartedEvent, INFINITE) != WAIT_OBJECT_0)
+    {
+        std::cerr << "Error in the wait\n";
+        return 1;
+    }
+
+    // TTD is now installed in the process and ready to record.
+    auto const pRecorder = TTD::MakeLiveRecorder(ClientGuid, "Hello, there!");
+    if (pRecorder == nullptr)
+    {
+        std::cerr << "Failed to get the recorder interface!\n";
+        return 2;
+    }
+
+    // We started TTD in manual mode, so nothing should be recording at this point.
+    if (auto const state = pRecorder->GetState(); state != TTD::ThreadRecordingState::NotStarted)
+    {
+        std::cerr << std::format("main: The current thread should not be recording yet! State is {}\n", GetStateName(state));
+        return 2;
+    }
+
+    // Record a simple single-threaded sort algorithm.
+    // The sorting is recorded as a single island with its own activity ID.
+    auto stdSortBuffer = randomSequence;
+    pRecorder->StartRecordingCurrentThread(StdSortActivity, TTD::InstructionCount::Max);
+    std::ranges::sort(stdSortBuffer);
+    pRecorder->StopRecordingCurrentThread();
+
+    // Verify that the sort worked as expected while being recorded.
+    if (!std::ranges::is_sorted(stdSortBuffer))
+    {
+        std::cerr << "main: std::sort didn't work right.\n";
+        return 2;
+    }
+
+    // Record all the pieces of a simple multithreaded sort algorithm.
+    // The sorting of all the asynchronous pieces is recorded in the trace,
+    // as islands belonging to the same activity.
+    auto multithreadedSortBuffer = randomSequence;
+    pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Max);
+    MultithreadedSort(pRecorder, multithreadedSortBuffer);
+    pRecorder->StopRecordingCurrentThread();
+
+    // Verify that the multithreaded sort worked as expected while being recorded.
+    if (!std::ranges::is_sorted(multithreadedSortBuffer))
+    {
+        std::cerr << "main: Multithreaded sort didn't work right.\n";
+        return 2;
+    }
+
+    // Obtain and print the full path to the TTD trace file that is being recorded.
+    wchar_t traceFilename[MAX_PATH];
+    pRecorder->GetFileName(traceFilename, std::size(traceFilename));
+    traceFilename[MAX_PATH - 1] = L'\0';
+    std::wcout << std::format(L"Trace file: {}\n", traceFilename);
+
+    // Close the recorder API, supplying a user data (in this case, just a short string).
+    pRecorder->Close("Adios!");
+
+    std::cout << "All done!\n";
+}

--- a/TTD/LiveRecorderApiSample/main.cpp
+++ b/TTD/LiveRecorderApiSample/main.cpp
@@ -11,8 +11,6 @@
 
 #include <TTD/TTDLiveRecorder.h>
 
-#pragma comment(lib, "TTDLiveRecorder")
-
 // {6DA58208-3BF5-4B80-A711-781098BC4445}
 static constexpr GUID ClientGuid = { 0x6da58208, 0x3bf5, 0x4b80, { 0xa7, 0x11, 0x78, 0x10, 0x98, 0xbc, 0x44, 0x45 } };
 

--- a/TTD/LiveRecorderApiSample/main.cpp
+++ b/TTD/LiveRecorderApiSample/main.cpp
@@ -1,4 +1,5 @@
 #include <Windows.h>
+#include <wrl.h>
 
 #include <thread>
 #include <future>
@@ -133,7 +134,7 @@ int wmain(int argc, wchar_t const* const* argv)
     }
 
     // TTD is now installed in the process and ready to record.
-    auto const pRecorder = TTD::MakeLiveRecorder(ClientGuid, "Hello, there!");
+    Microsoft::WRL::ComPtr<TTD::ILiveRecorder> const pRecorder{ TTD::MakeLiveRecorder(ClientGuid, "Hello, there!") };
     if (pRecorder == nullptr)
     {
         std::cerr << "Failed to get the recorder interface!\n";
@@ -166,7 +167,7 @@ int wmain(int argc, wchar_t const* const* argv)
     // as islands belonging to the same activity.
     auto multithreadedSortBuffer = randomSequence;
     pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Max);
-    MultithreadedSort(pRecorder, multithreadedSortBuffer);
+    MultithreadedSort(pRecorder.Get(), multithreadedSortBuffer);
     pRecorder->StopRecordingCurrentThread();
 
     // Verify that the multithreaded sort worked as expected while being recorded.

--- a/TTD/LiveRecorderApiSample/main.cpp
+++ b/TTD/LiveRecorderApiSample/main.cpp
@@ -53,7 +53,7 @@ void MultithreadedSort(TTD::ILiveRecorder* pRecorder, std::span<int> span)
                 // Asynchronous sorting of the hi span half.
                 // This gets to run on a separate thread,
                 // so in order to record we need to do it explicitly.
-                pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Max);
+                pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Invalid);
                 MultithreadedSort(pRecorder, hiSpan);
                 pRecorder->StopRecordingCurrentThread();
             });
@@ -148,7 +148,7 @@ int wmain(int argc, wchar_t const* const* argv)
     // Record a simple single-threaded sort algorithm.
     // The sorting is recorded as a single island with its own activity ID.
     auto stdSortBuffer = randomSequence;
-    pRecorder->StartRecordingCurrentThread(StdSortActivity, TTD::InstructionCount::Max);
+    pRecorder->StartRecordingCurrentThread(StdSortActivity, TTD::InstructionCount::Invalid);
     std::ranges::sort(stdSortBuffer);
     pRecorder->StopRecordingCurrentThread();
 
@@ -163,7 +163,7 @@ int wmain(int argc, wchar_t const* const* argv)
     // The sorting of all the asynchronous pieces is recorded in the trace,
     // as islands belonging to the same activity.
     auto multithreadedSortBuffer = randomSequence;
-    pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Max);
+    pRecorder->StartRecordingCurrentThread(MultithreadedSortActivity, TTD::InstructionCount::Invalid);
     MultithreadedSort(pRecorder.Get(), multithreadedSortBuffer);
     pRecorder->StopRecordingCurrentThread();
 

--- a/TTD/LiveRecorderApiSample/main.cpp
+++ b/TTD/LiveRecorderApiSample/main.cpp
@@ -107,7 +107,6 @@ int wmain(int argc, wchar_t const* const* argv)
     auto ttdResult = reinterpret_cast<INT_PTR>(ShellExecuteW(
         nullptr,
         L"runas",
-        //L"TTD.exe",
         (binDir / L"TTD" / L"TTD.exe").c_str(),
         arguments.c_str(),
         nullptr,
@@ -184,7 +183,7 @@ int wmain(int argc, wchar_t const* const* argv)
     std::wcout << std::format(L"Trace file: {}\n", traceFilename);
 
     // Close the recorder API, supplying a user data (in this case, just a short string).
-    pRecorder->Close("Adios!");
+    pRecorder->Close("Done!");
 
     std::cout << "All done!\n";
 }

--- a/TTD/LiveRecorderApiSample/packages.config
+++ b/TTD/LiveRecorderApiSample/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.TimeTravelDebugging.Apis" version="0.8.123" targetFramework="native" />
+</packages>

--- a/TTD/LiveRecorderApiSample/packages.config
+++ b/TTD/LiveRecorderApiSample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.TimeTravelDebugging.Apis" version="0.8.123" targetFramework="native" />
+  <package id="Microsoft.TimeTravelDebugging.Apis" version="0.8.127" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This new sample serves to illustrate how to use TTD's live recorder API in order to control precisely what is recorded in the trace file.