### PR TITLE
Added a XML attribute to configure waiting on OK string for GDB monitor command

### DIFF
--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/GdbSrvControllerLib.cpp
@@ -221,6 +221,7 @@ public:
             throw _com_error(E_FAIL);
         }
 
+        ConfigExdiGdbServerHelper& cfgData = ConfigExdiGdbServerHelper::GetInstanceCfgExdiGdbServer(nullptr);
         messageLength = min(messageLength, C_MAX_MONITOR_CMD_BUFFER);
         bool replyDone = false;
         do
@@ -247,15 +248,23 @@ public:
                     unsigned char highByte = ((AciiHexToNumber(reply[pos]) << 4) & 0xf0);
                     monitorResult[monitorResult.GetLength() - 1] = highByte | (AciiHexToNumber(reply[pos + 1]) & 0x0f);
                 }
-                //  Try to read more packets
-                bool IsPollingChannelMode = false;
-                if (m_pRspClient->ReceiveRspPacketEx(reply, core, true, IsPollingChannelMode, false))
+
+                if (cfgData.IsGdbMonitorCmdDoNotWaitOnOKEnable())
                 {
-                    messageLength = reply.length();
+                    replyDone = true;
                 }
                 else
                 {
-                    replyDone = true;
+                    //  Try to read more packets
+                    bool IsPollingChannelMode = false;
+                    if (m_pRspClient->ReceiveRspPacketEx(reply, core, true, IsPollingChannelMode, false))
+                    {
+                        messageLength = reply.length();
+                    }
+                    else
+                    {
+                        replyDone = true;
+                    }
                 }
             }
         }

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.cpp
@@ -101,6 +101,7 @@ typedef struct
     WCHAR fTreatSwBpAsHwBp[C_MAX_ATTR_LENGTH];          //  Treat SW bp as a HW bp.
     WCHAR fForcedLegacyResumeStepCommands[C_MAX_ATTR_LENGTH]; //  Flag if set, then use the legacy step/resume command mode.
     WCHAR fServerRequirePAMemoryAccess[C_MAX_ATTR_LENGTH]; //  if set the server requires PAs for all memory access R/W.
+    WCHAR fGdbMonitorCmdDoNotWaitOnOK[C_MAX_ATTR_LENGTH]; //  if set the server requires PAs for all memory access R/W.
 } ConfigExdiDataEntry;
 
 typedef struct
@@ -177,6 +178,7 @@ const WCHAR gdbServerAgentNamePacket[] = L"agentNamePacket";
 const WCHAR gdbQSupportedPacket[] = L"qSupportedPacket";
 const WCHAR gdbTreatSwBpAsHwBp[] = L"enableTreatingSwBpAsHwBp";
 const WCHAR gdbRequirePAMemoryAccess[] = L"requirePAMemoryAccess";
+const WCHAR gdbMonitorCmdDoNotWaitOnOK[] = L"gdbMonitorCmdDoNotWaitOnOK";
 const WCHAR gdbServerUuid[] = L"uuid";
 const WCHAR displayCommPackets[] = L"displayCommPackets";
 const WCHAR debuggerSessionByCore[] = L"debuggerSessionByCore";
@@ -248,15 +250,16 @@ const XML_ATTRNAME_HANDLER_STRUCT attrExdiTargetHandlerMap[] =
 //  General debugger information - handler map
 const XML_ATTRNAME_HANDLER_STRUCT attrExdiServerHandlerMap[] =
 {
-    {exdiGdbServerConfigData, gdbServerAgentNamePacket, XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, agentNamePacket), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, gdbServerUuid,            XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, uuid), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, displayCommPackets,       XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fDisplayCommPackets), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, debuggerSessionByCore,    XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fDebuggerSessionByCore), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, enableThrowExceptions,    XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fExceptionThrowEnabled), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, gdbQSupportedPacket,      XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, qSupportedPacket), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, gdbTreatSwBpAsHwBp,       XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fTreatSwBpAsHwBp), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, forceLegacyResumeStepCmds,XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fForcedLegacyResumeStepCommands), C_MAX_ATTR_LENGTH},
-    {exdiGdbServerConfigData, gdbRequirePAMemoryAccess, XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fServerRequirePAMemoryAccess), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbServerAgentNamePacket,   XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, agentNamePacket), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbServerUuid,              XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, uuid), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, displayCommPackets,         XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fDisplayCommPackets), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, debuggerSessionByCore,      XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fDebuggerSessionByCore), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, enableThrowExceptions,      XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fExceptionThrowEnabled), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbQSupportedPacket,        XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, qSupportedPacket), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbTreatSwBpAsHwBp,         XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fTreatSwBpAsHwBp), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, forceLegacyResumeStepCmds,  XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fForcedLegacyResumeStepCommands), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbRequirePAMemoryAccess,   XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fServerRequirePAMemoryAccess), C_MAX_ATTR_LENGTH},
+    {exdiGdbServerConfigData, gdbMonitorCmdDoNotWaitOnOK, XmlDataHelpers::XmlGetStringValue, FIELD_OFFSET(ConfigExdiDataEntry, fGdbMonitorCmdDoNotWaitOnOK), C_MAX_ATTR_LENGTH},
 };
 
 //  Attribute name - handler map for the GdbServer server tag info
@@ -819,6 +822,7 @@ HRESULT XmlDataHelpers::HandleTagAttributeList(_In_ TAG_ATTR_LIST* const pTagAtt
                     pConfigTable->component.fTreatSwBpAsHwBp = (_wcsicmp(exdiData.fTreatSwBpAsHwBp, L"yes") == 0) ? true : false;
                     pConfigTable->component.fForcedLegacyResumeStepCommands = (_wcsicmp(exdiData.fForcedLegacyResumeStepCommands, L"yes") == 0) ? true : false;
                     pConfigTable->component.fPAMemoryAccess = (_wcsicmp(exdiData.fServerRequirePAMemoryAccess, L"yes") == 0) ? true : false;
+                    pConfigTable->component.fgdbMonitorCmdDoNotWaitOnOK = (_wcsicmp(exdiData.fGdbMonitorCmdDoNotWaitOnOK, L"yes") == 0) ? true : false;
                     isSet = true;
                 }
             }

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/XmlDataHelpers.h
@@ -57,7 +57,8 @@ namespace GdbSrvControllerLib
         std::wstring qSupportedPacket;  //  GDB server supported, if this empty then will send the default "qsupported" packet
         bool fTreatSwBpAsHwBp;          //  GDB server client will convert SW bp as HW bp.
         bool fForcedLegacyResumeStepCommands; //  Flag if set the GDB server will use the legacy resume/step command mode
-        bool fPAMemoryAccess;          //  GDB server reuires memory access via PA
+        bool fPAMemoryAccess;           //  GDB server reuires memory access via PA
+        bool fgdbMonitorCmdDoNotWaitOnOK; //  Flag if set then the GDB monitor response processing won't wait on the "OK" string
     } ConfigExdiData;
 
     //  This type indicates the Target data.

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.cpp
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.cpp
@@ -344,6 +344,11 @@ class ConfigExdiGdbServerHelper::ConfigExdiGdbServerHelperImpl
         return m_ExdiGdbServerData.component.fPAMemoryAccess;
     }
 
+    inline bool ConfigExdiGdbServerHelperImpl::IsGdbMonitorCmdDoNotWaitOnOKEnable()
+    {
+        return m_ExdiGdbServerData.component.fgdbMonitorCmdDoNotWaitOnOK;
+    }
+
     private:
     CComPtr<IXmlReader> m_XmlLiteReader;
     CComPtr<IStream> m_IStream;
@@ -889,4 +894,10 @@ bool ConfigExdiGdbServerHelper::GetServerRequirePAMemoryAccess()
 {
     assert(m_pConfigExdiGdbServerHelperImpl != nullptr);
     return m_pConfigExdiGdbServerHelperImpl->GetServerRequirePAMemoryAccess();
+}
+
+bool ConfigExdiGdbServerHelper::IsGdbMonitorCmdDoNotWaitOnOKEnable()
+{
+    assert(m_pConfigExdiGdbServerHelperImpl != nullptr);
+    return m_pConfigExdiGdbServerHelperImpl->IsGdbMonitorCmdDoNotWaitOnOKEnable();
 }

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/cfgExdiGdbSrvHelper.h
@@ -66,6 +66,7 @@ class ConfigExdiGdbServerHelper final
         bool ReadConfigFile(_In_ PCWSTR pXmlConfigFile);
         void SetXmlBufferToParse(_In_ PCWSTR pXmlConfigFile);
         void SetTargetArchitecture(_In_ TargetArchitecture targetArch);
+        bool IsGdbMonitorCmdDoNotWaitOnOKEnable();
 
     private:
         ConfigExdiGdbServerHelper(_In_opt_ PCWSTR pXmlConfigFile);

--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
@@ -178,7 +178,7 @@
 
   <!-- QEMU SW simulator GDB server configuration -->
   <ExdiTarget Name = "QEMU">
-    <ExdiGdbServerConfigData agentNamePacket = "" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "yes" qSupportedPacket="qSupported:xmlRegisters=aarch64,i386">
+    <ExdiGdbServerConfigData agentNamePacket = "" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "yes" qSupportedPacket="qSupported:xmlRegisters=aarch64,i386" gdbMonitorCmdDoNotWaitOnOK = "yes">
       <ExdiGdbServerTargetData targetArchitecture = "ARM64" targetFamily = "ProcessorFamilyARM64" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xffe" targetDescriptionFile = "target.xml" />
       <GdbServerConnectionParameters MultiCoreGdbServerSessions = "no" MaximumGdbServerPacketLength = "1024" MaximumConnectAttempts = "3" SendPacketTimeout = "100" ReceivePacketTimeout = "3000">
         <Value HostNameAndPort="LocalHost:1234" />


### PR DESCRIPTION
This PR is to fix the issue reported by Chris Fernald that caused waiting for the "OK" response string at the end of the custom GDB response monitor command. 
This PR defines a new XML Server attribute to configure this functionality (enable/disable "not" waiting on "OK" string).