### PR TITLE
Fix the new links that should point to the TTD.exe documentation

### DIFF
--- a/TTD/docs/TTDLiveRecorder.h/ILiveRecorder_DumpHeaps.md
+++ b/TTD/docs/TTDLiveRecorder.h/ILiveRecorder_DumpHeaps.md
@@ -27,7 +27,7 @@ Note that this method might record a large amount of data in the trace file.
 TTD doesn't perform any differential or incremental snapshotting,
 so the entirety of the process heaps will be recorded each time the method is called.
 
-Also note that in automatic mode [`TTD.exe -recordMode Automatic`](https://review.learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-live-recorder-api?branch=domars-ttd-live-recorder), which is TTD's default,
+Also note that in automatic mode [`TTD.exe -recordMode Automatic`](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-exe-command-line-util#reducing-overhead-of-tracing), which is TTD's default,
 the recorder will already have recorded all the memory of the process as part of its initialization,
 so calling this method might be redundant and wasteful.
 Caution and common sense should be exercised to avoid bloating the trace file with large blocks of redundant data.

--- a/TTD/docs/TTDLiveRecorder.h/ILiveRecorder_DumpModuleData.md
+++ b/TTD/docs/TTDLiveRecorder.h/ILiveRecorder_DumpModuleData.md
@@ -34,7 +34,7 @@ and may record "torn" data if it's simultaneously written. See [`DumpSnapshot`](
 
 This method has no use restrictions.
 
-Also note that in automatic mode [`TTD.exe -recordMode Automatic`](https://review.learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-live-recorder-api?branch=domars-ttd-live-recorder), which is TTD's default,
+Also note that in automatic mode [`TTD.exe -recordMode Automatic`](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-exe-command-line-util#reducing-overhead-of-tracing), which is TTD's default,
 the recorder will already have recorded all the memory of the process as part of its initialization,
 and any additional modules as soon as they are loaded, so calling this method might be redundant and wasteful.
 Caution and common sense should be exercised to avoid bloating the trace file with large blocks of redundant data.

--- a/TTD/docs/TTDLiveRecorder.h/ILiveRecorder_DumpSnapshot.md
+++ b/TTD/docs/TTDLiveRecorder.h/ILiveRecorder_DumpSnapshot.md
@@ -48,7 +48,7 @@ Note that if given a large buffer this method will record it in its entirety in 
 TTD doesn't perform any differential or incremental snapshotting,
 so the entirety of the buffer will be recorded each time the method is called.
 
-Also note that in automatic mode [`TTD.exe -recordMode Automatic`](https://review.learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-live-recorder-api?branch=domars-ttd-live-recorder), which is TTD's default,
+Also note that in automatic mode [`TTD.exe -recordMode Automatic`](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-exe-command-line-util#reducing-overhead-of-tracing), which is TTD's default,
 the recorder will already have recorded all the memory of the process as part of its initialization,
 so calling this method might be redundant and wasteful.
 Caution and common sense should be exercised to avoid bloating the trace file with large blocks of redundant data.


### PR DESCRIPTION
I inadvertently used the wrong link.