### PR TITLE
Handle the Trace32 read memory command when the memory type is unknown

### DIFF
--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/TargetGdbServerHelpers.h
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/TargetGdbServerHelpers.h
@@ -68,6 +68,10 @@ public:
                 assert(false);
             }
         }
+        else
+        {
+            pFormat = (is64BitArchitecture) ? "m%I64x,%x" : "m%x,%x";
+        }
         return pFormat;
     }
 
@@ -104,6 +108,10 @@ public:
             {
                 assert(false);
             }
+        }
+        else
+        {
+            pFormat = (is64BitArchitecture) ? "M%I64x," : "M%x,";
         }
 
         return pFormat;
@@ -186,6 +194,37 @@ public:
     {
 
         return is64BitArchitecture ? "M%I64x," : "M%x,";
+    }
+
+    static inline PCSTR GetDynPAConfigModeCmd(_In_ bool mode)
+    {
+        return (mode) ? "Qqemu.PhyMemMode:1" : "Qqemu.PhyMemMode:0";
+    }
+};
+
+class QEMUDGdbServerMemoryHelpers
+{
+public:
+
+    static inline PCSTR GetGdbSrvReadMemoryCmd(
+        _In_ memoryAccessType memType,
+        _In_ bool is64BitArchitecture)
+    {
+
+        return is64BitArchitecture ? "m%I64x,%x" : "m%x,%x";
+    }
+
+    static inline PCSTR GetGdbSrvWriteMemoryCmd(
+        _In_ memoryAccessType memType,
+        _In_ bool is64BitArchitecture)
+    {
+
+        return is64BitArchitecture ? "M%I64x," : "M%x,";
+    }
+
+    static inline PCSTR GetDynPAConfigModeCmd(_In_ bool mode)
+    {
+        return (mode) ? "Qqemu.PhyMemMode:1" : "Qqemu.PhyMemMode:0";
     }
 };
 


### PR DESCRIPTION
This handles the Trace32 GDB server issue reported by Pedro Texeira (tracked by ADO ticket:49235111).

- This PR fixes the function _ExdiGdbSrv_!Trace32GdbServerMemoryHelpers::GetGdbSrvReadMemoryCmd() to always return a command memory string value (rather than nullptr) when the memory type command parameter has not been determined (it default to VA type).
-The function now returns the "generic GDB memory access command" for the Trace 32 GDB server that supports customized GDB memory commands depending on the memory type parameter requested.
