### PR TITLE
Update the extension gallery README.MD to include information about views

### DIFF
--- a/Manifest/README.MD
+++ b/Manifest/README.MD
@@ -51,6 +51,32 @@ Each `NamedExtension` in the `ObjectExtensionList` can have three properties:
 * **Namespace** - The acquired namespace (ex. "Debugger.Models.Module.Contents"). This is an optional property. If it is provided then "Property" property must be provided.
 * **Property** - The property under the model which will be added to retrieve the acquired namespace (ex. "Contents" i.e. under "Debugger.Models.Module" will be added a property "Contents"). This is a mandatory property if the Namespace property is provided, otherwise shouldn’t be provided.
 
+#### Views
+*To use Views, you need to be running WinDbg 1.2407.24003.0 or newer* 
+
+If your script wants to place icons on the "Extensions" tab of the WinDbg ribbon which, when invoked, will open a UI window visualizing the results of a data model query, each of those icons needs to be defined as a `View` in a `Views` tag.
+
+Each `View` in the `Views` tag binds a coupling of an "Icon" and a "Name" provided by the script to a "Data Model Query" and a "View Type".  The `View` tag contains the following properties:
+
+* **Query** (mandatory): The data model query which will be invoked to present the data.
+* **Name** (mandatory): The name of the view.  This is the text which goes below/beside the icon on the ribbon.
+* **ViewKind** (optional): The kind of view.  If present, this must be one of **Tree** or **Grid**.  If not present, the UI will select a default form to present the query in.  Note that additional view types will be forthcoming in future debugger releases.
+* **Group** (optional): If present, indicates that the view is part of a group.  Being part of a group places the view icon and name under a drop-down on the ribbon.
+* **IsPrimary** (optional): A boolean value which, if present, indicates that this view's icons should be used as the group's icons.  Only one view within a group may mark the **IsPrimary** attribute as true.  If no view within a group indicates that it is primary, the UI will pick one of the views arbitrarily to select group icons for the drop-down.
+* **LargeIconData** (optional): A string hexdump of the 32x32 PNG data which comprises the large icon for the view.  Either this or the **LargeIcon** attribute (but not both) **MUST** be present.
+* **SmallIconData** (optional): A string hexdump of the 16x16 PNG data which comprises the small icon for the view.  Either this or the **SmallIcon** attribute (but not both) **MUST** be present.
+* **FilePathKind** (optional): If using **LargeIcon** or **SmallIcon** attributes, this indicates what kind of file paths those elements refer to.  As with other **FilePathKind** attributes in an extension gallery manifest, these can be **PackageRelative**, **RepositoryRelative**, or **Absolute**.
+* **LargeIcon** (optional): A path to a 32x32 PNG which is the large icon for the view.  The path kind is indicated by the **FilePathKind** attribute.  Either this or the **LargeIconData** attribute (but not both) **MUST** be present.
+* **SmallIcon** (optional): A path to a 16x16 PNG which is the small icon for the view.  The path kind is indicated by the **FilePathKind** attribute.  Either this or the **SmallIconData** attribute (but not both) **MUST** be present.
+
+There is one important thing to note about the icons here.  While you **MUST** provide both a large (32x32 PNG) icon and a small (16x16 PNG) icon, that can be done in one of two ways:
+
+* As a binary blob in the manifest itself using the **LargeIconData** and **SmallIconData** attributes
+* As a file in the extension package using the **LargeIcon** and **SmallIcon** attributes
+
+You can use the "as a file in the extension package" method **if and only if** your extension will **always** be on the local disk.  If your extension is included in a network based extension gallery, you **MUST CURRENTLY** use the binary blob method.
+
+
 ## Make your own gallery
 You can also make your own extension gallery! You'll want to look through all three files in this folder to understand what to do.
 ### Manifest File - manifest.n.xml


### PR DESCRIPTION
The latest public debugger release (1.2407.24003.0) includes the ability to define views (bindings of icon+name to data model query + view kind) which will place icons on the "Extensions" tab of the WinDbg ribbon.  This is done through extension gallery manifests.  Here is the basic documentation for doing so.  Several extensions that ship with the debugger itself (including kdexts and the Linux kernel debug extension) make use of this and can be used for reference.