### PR TITLE
Update Get-Ttd.ps1

### DIFF
--- a/TTD/LiveRecorderApiSample/Get-Ttd.ps1
+++ b/TTD/LiveRecorderApiSample/Get-Ttd.ps1
@@ -1,8 +1,7 @@
 param(
     $OutDir = ".\TTDDownload",
     [ValidateSet("x64", "x86", "arm64")]
-    $Arch = "x64",
-    $MsixBundle = ""
+    $Arch = "x64"
 )
 
 # Ensure the output directory exists
@@ -16,64 +15,48 @@ if (!(Test-Path $TempDir)) {
     $null = mkdir $TempDir
 }
 
-$MsixBundleZip = "$TempDir\ttd.zip"
+# Determine if the destination already contains binaries
+$extensions = @('.dll', '.exe', '.sys')
+$existingBinaries = (Get-ChildItem -recurse $OutDir | Where-Object Extension -In $extensions).Count -gt 0
 
-if ($MsixBundle -eq "") {
-    Write-Host "Downloading TTD from https://aka.ms/ttd/download"
+# Download the appinstaller to find the current uri for the msixbundle
+Invoke-WebRequest https://aka.ms/ttd/download -OutFile $TempDir\ttd.appinstaller
 
-    # Download the appinstaller to find the current uri for the msixbundle
-    Invoke-WebRequest https://aka.ms/ttd/download -OutFile $TempDir\ttd.appinstaller
+# Download the msixbundle
+$msixBundleUri = ([xml](Get-Content $TempDir\ttd.appinstaller)).AppInstaller.MainBundle.Uri
 
-    # Download the msixbundle
-    $msixBundleUri = ([xml](Get-Content $TempDir\ttd.appinstaller)).AppInstaller.MainBundle.Uri
-
-    if ($PSVersionTable.PSVersion.Major -lt 6) {
-        # This is a workaround to get better performance on older versions of PowerShell
-        $ProgressPreference = 'SilentlyContinue'
-    }
-
-    # Download the msixbundle (but name as zip for older versions of Expand-Archive)
-    Invoke-WebRequest $msixBundleUri -OutFile $MsixBundleZip
-} else {
-    # Copy and rename the bundle so it can be expanded.
-    Copy-Item $MsixBundle -Destination $MsixBundleZip
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    # This is a workaround to get better performance on older versions of PowerShell
+    $ProgressPreference = 'SilentlyContinue'
 }
+
+# Download the msixbundle (but name as zip for older versions of Expand-Archive)
+Invoke-WebRequest $msixBundleUri -OutFile $TempDir\ttd.zip
 
 # Extract the 3 msix files (plus other files)
-Expand-Archive -DestinationPath $TempDir\UnzippedBundle $MsixBundleZip -Force
+Expand-Archive -DestinationPath $TempDir\UnzippedBundle $TempDir\ttd.zip -Force
 
-# We only need these file types.
-$extensions = @('.dll', '.exe')
-
-$ttdRecorderFiles = @(
-    "TTD.exe",
-    "TTDInject.exe",
-    "TTDLiveRecorder.dll",
-    "TTDLoader.dll",
-    "TTDRecord.dll",
-    "TTDRecordCPU.dll"
-)
-
-foreach ($archName in @("x64", "x86", "ARM64")) {
-    $msixName = "TTD-$archName"
-    $msixOutDir = "$OutDir\$archName"
-
-    if (!(Test-Path $msixOutDir)) {
-        $null = mkdir $msixOutDir
-    }
-
-    # Rename msix (for older versions of Expand-Archive) and extract TTD.
-    Rename-Item "$TempDir\UnzippedBundle\$msixName.msix" "$msixName.zip"
-    Expand-Archive -DestinationPath $msixOutDir "$TempDir\UnzippedBundle\$msixName.zip" -Force
-
-    # Remove unnecessary files
-    Get-ChildItem -Recurse -File $msixOutDir -Exclude $ttdRecorderFiles |
-        Remove-Item -Force
-
-    # Remove subdirectories
-    Get-ChildItem -Directory $msixOutDir |
-        Remove-Item -Recurse -Force
+# Expand the build you want - also renaming the msix to zip for Windows PowerShell
+$fileName = switch ($Arch) {
+    "x64"   { "TTD-x64"   }
+    "x86"   { "TTD-x86"   }
+    "arm64" { "TTD-ARM64" }
 }
+
+# Rename msix (for older versions of Expand-Archive) and extract the debugger
+Rename-Item "$TempDir\UnzippedBundle\$fileName.msix" "$fileName.zip"
+Expand-Archive -DestinationPath "$OutDir" "$TempDir\UnzippedBundle\$fileName.zip"
 
 # Delete the temp directory
 Remove-Item $TempDir -Recurse -Force
+
+# Remove unnecessary files, if it is safe to do so
+if (-not $existingBinaries) {
+    Get-ChildItem -Recurse -File $OutDir |
+        Where-Object Extension -NotIn $extensions |
+        Remove-Item -Force
+
+Remove-Item -Recurse -Force (Join-Path $OutDir "AppxMetadata")
+} else {
+    Write-Host "Detected pre-existing binaries in '$OutDir' so did not remove any files from TTD package."
+}


### PR DESCRIPTION
missing ***.sys**, source [Get-Ttd.ps1](https://learn.microsoft.com/windows-hardware/drivers/debuggercmds/time-travel-debugging-ttd-exe-command-line-util#download-the-ttdexe-command-line-utility-package-and-extract-the-files-manually)