### PR TITLE
Update the exdiconfigdata.xml attribute enableThrowExceptionOnMemoryE…

### DIFF
--- a/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
+++ b/Exdi/exdigdbsrv/GdbSrvControllerLib/exdiConfigData.xml
@@ -2,7 +2,7 @@
 
   <!-- Lauterbach Trace32 HW debugger GDB server configuration -->
   <ExdiTarget Name = "Trace32">
-    <ExdiGdbServerConfigData agentNamePacket = "QMS.windbg" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "no" qSupportedPacket="">
+    <ExdiGdbServerConfigData agentNamePacket = "QMS.windbg" uuid = "72d4aeda-9723-4972-b89a-679ac79810ef" displayCommPackets = "yes" debuggerSessionByCore = "no" enableThrowExceptionOnMemoryErrors = "yes" qSupportedPacket="">
       <ExdiGdbServerTargetData targetArchitecture = "ARM64" targetFamily = "ProcessorFamilyARM64" numberOfCores = "1" EnableSseContext = "no" heuristicScanSize = "0xffe" targetDescriptionFile = ""/>
       <GdbServerConnectionParameters MultiCoreGdbServerSessions = "no" MaximumGdbServerPacketLength = "1024" MaximumConnectAttempts = "3" SendPacketTimeout = "100" ReceivePacketTimeout = "3000">
         <Value HostNameAndPort="LocalHost:65001" />


### PR DESCRIPTION
Enable the enableThrowExceptionOnMemoryErrors attribute in the exdiconfigdata.xml file for JTAG Trace32 targets. This is necessary to employ a faster heuristic for locating the system application's base address