### PR TITLE
Fix Get-Ttd path issue and support directories with spaces

### DIFF
--- a/TTD/LiveRecorderApiSample/Get-Ttd.cmd
+++ b/TTD/LiveRecorderApiSample/Get-Ttd.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call powershell "%~dp0\Get-Ttd.ps1" %*
+call powershell -File "%~dp0Get-Ttd.ps1" %*

--- a/TTD/ReplayApi/GetTtd/Get-Ttd.cmd
+++ b/TTD/ReplayApi/GetTtd/Get-Ttd.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call powershell "%~dp0\Get-Ttd.ps1" %*
+call powershell -File "%~dp0\Get-Ttd.ps1" %*

--- a/TTD/build.cmd
+++ b/TTD/build.cmd
@@ -5,7 +5,6 @@ setlocal enabledelayedexpansion
 
 :: Capture remaining arguments as msbuild arguments
 set _script_dir=%~dp0
-shift
 set _msbuild_args=%*
 
 :: Make sure necessary tools are available

--- a/TTD/build.cmd
+++ b/TTD/build.cmd
@@ -4,6 +4,7 @@
 setlocal enabledelayedexpansion
 
 :: Capture remaining arguments as msbuild arguments
+set _script_dir=%~dp0
 shift
 set _msbuild_args=%*
 
@@ -21,24 +22,24 @@ echo msbuild.exe must be on command line. Run this script from a developer promp
 
 :: Make sure the TTD bits are downloaded for both projects
 
-if not exist %~dp0LiveRecorderApiSample\TTDDownload\x64\TTDRecordCPU.dll (
-  pushd %~dp0LiveRecorderApiSample
+if not exist "%_script_dir%LiveRecorderApiSample\TTDDownload\x64\TTDRecordCPU.dll" (
+  pushd "%_script_dir%LiveRecorderApiSample"
   call Get-Ttd.cmd
-  if not exist %~dp0LiveRecorderApiSample\TTDDownload\x64\TTDRecordCPU.dll echo Error: LiveRecorderApiSample Get-Ttd.cmd failed& goto :eof
+  if not exist "%_script_dir%LiveRecorderApiSample\TTDDownload\x64\TTDRecordCPU.dll" popd & echo Error: LiveRecorderApiSample Get-Ttd.cmd failed& goto :eof
   popd
 )
 
-if not exist %~dp0ReplayApi\GetTtd\TTDDownload\x64\TTDReplay.dll (
-  pushd %~dp0ReplayApi\GetTtd
+if not exist "%_script_dir%ReplayApi\GetTtd\TTDDownload\x64\TTDReplay.dll" (
+  pushd "%_script_dir%ReplayApi\GetTtd"
   call Get-Ttd.cmd
-  if not exist %~dp0ReplayApi\GetTtd\TTDDownload\x64\TTDReplay.dll echo Error: ReplayApi Get-Ttd.cmd failed& goto :eof
+  if not exist "%_script_dir%ReplayApi\GetTtd\TTDDownload\x64\TTDReplay.dll" popd & echo Error: ReplayApi Get-Ttd.cmd failed& goto :eof
   popd
 )
 
 :: Build each sample
 set _error=0
-for /F %%F in ('dir /s /b /a:-d %~dp0packages.config') do (
-  call :Build %%~dpF
+for /F "delims=$" %%F in ('dir /s /b /a:-d "%_script_dir%packages.config"') do (
+  call :Build "%%~dpF"
   if !_error! NEQ 0 exit /B 1
 )
 


### PR DESCRIPTION
Fixed some issues in build.cmd:
1. Get-Ttd was not going to the right location because a "shift" was added earlier in the script. Fixed.
2. Flushed out bugs when repo path contains spaces.